### PR TITLE
Eliminate unnecessary module imports

### DIFF
--- a/API/application/iotjs.py
+++ b/API/application/iotjs.py
@@ -14,7 +14,6 @@
 
 import base
 import json
-import os
 
 from API.common import console, paths, utils
 
@@ -214,14 +213,14 @@ class Application(base.ApplicationBase):
         '''
 
         # Read testsets
-        testsets_file = os.path.join(paths.IOTJS_TEST_PATH, 'testsets.json')
+        testsets_file = utils.join(paths.IOTJS_TEST_PATH, 'testsets.json')
         testsets = {}
 
         with open(testsets_file, 'r') as testsets_p:
             testsets = json.load(testsets_p)
 
         # Read skip file
-        skip_file = os.path.join(paths.PROJECT_ROOT, 'API/testrunner/iotjs-skiplist.json')
+        skip_file = utils.join(paths.PROJECT_ROOT, 'API/testrunner/iotjs-skiplist.json')
         skip_list = self.get_skiplist(skip_file)
         dev_type = self.device.get_type()
         skip_tests = skip_list[dev_type]['testfiles']

--- a/API/application/jerryscript.py
+++ b/API/application/jerryscript.py
@@ -150,7 +150,7 @@ class Application(base.ApplicationBase):
         '''
 
         # # Read skip file
-        skip_file = os.path.join(paths.PROJECT_ROOT, 'API/testrunner/jerry-skiplist.json')
+        skip_file = utils.join(paths.PROJECT_ROOT, 'API/testrunner/jerry-skiplist.json')
         skip_list = self.get_skiplist(skip_file)
         dev_type = self.device.get_type()
         skip_tests = skip_list[dev_type]['testfiles']

--- a/API/common/reporter.py
+++ b/API/common/reporter.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-from . import console
+import console
 
 
 def report_testset(testset):

--- a/API/common/utils.py
+++ b/API/common/utils.py
@@ -15,11 +15,11 @@
 import console
 import json
 import os
+import platform
+import re
 import shutil
 import subprocess
 import time
-import re
-import platform
 
 
 class TimeoutException(Exception):

--- a/API/device/__init__.py
+++ b/API/device/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import artik053
 import rpi2
 import stm32f4dis
-import artik053
 
 
 DEVICES = {

--- a/API/device/artik053.py
+++ b/API/device/artik053.py
@@ -15,7 +15,6 @@
 import base
 import connection
 import re
-import signal
 import time
 
 from API.common import console, paths, utils

--- a/API/device/rpi2.py
+++ b/API/device/rpi2.py
@@ -15,7 +15,6 @@
 import base
 import connection
 import json
-import time
 
 from API.common import console, paths, utils
 

--- a/API/device/stm32f4dis.py
+++ b/API/device/stm32f4dis.py
@@ -15,7 +15,6 @@
 import base
 import connection
 import re
-import signal
 import time
 
 from API.common import console, paths, utils

--- a/API/os/linux.py
+++ b/API/os/linux.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import base
-import os
 
 
 class OperatingSystem(base.OperatingSystemBase):

--- a/API/os/nuttx.py
+++ b/API/os/nuttx.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 import base
-import binascii
-import ConfigParser
-import os
-import socket
 
 from API.common import paths, utils
 

--- a/driver.py
+++ b/driver.py
@@ -14,10 +14,7 @@
 
 import argparse
 
-import API.application
-import API.device
-import API.os
-import API.testrunner
+import API
 
 
 def parse_options():


### PR DESCRIPTION
There are some unused Python imports that should be removed.

JSRemoteTest-DCO-1.0-Signed-off-by: Roland Takacs rtakacs.u-szeged@partner.samsung.com