### PR TITLE
Fix firebase module import

### DIFF
--- a/API/testrunner/testrunner.py
+++ b/API/testrunner/testrunner.py
@@ -14,10 +14,9 @@
 
 import json
 
-import firebase_admin
+from firebase_admin import credentials, db, initialize_app
 
 from API.common import paths, reporter, utils
-
 
 
 TEST_RESULTS_WEB_PATH = {
@@ -124,17 +123,17 @@ class TestRunner(object):
             return
 
         # Fetch the service account key JSON file contents
-        cred = firebase_admin.credentials.Certificate(serviceAccountKey)
+        cred = credentials.Certificate(serviceAccountKey)
 
         # Initialize the app with a service account, granting admin privileges
-        firebase_admin.initialize_app(cred, {
+        initialize_app(cred, {
             'databaseURL': "https://remote-testrunner.firebaseio.com",
             'databaseAuthVariableOverride': {
                 'uid': 'testrunner-service'
             }
         })
 
-        ref = firebase_admin.db.reference(app.get_name() + '/' + device_dir)
+        ref = db.reference(app.get_name() + '/' + device_dir)
 
         with open(result_file_path) as result_file:
             data = json.load(result_file)


### PR DESCRIPTION
Fixing the firebase module import because a clean-up patch messed that up:

```
Traceback (most recent call last):
  File "/home/rtakacs/Projects/js-remote-test/driver.py", line 96, in <module>
    main()
  File "/home/rtakacs/Projects/js-remote-test/driver.py", line 93, in main
    testrunner.run(options.public)
  File "/home/rtakacs/Projects/js-remote-test/API/testrunner/testrunner.py", line 216, in run
    self.__save(is_publish)
  File "/home/rtakacs/Projects/js-remote-test/API/testrunner/testrunner.py", line 137, in __save
    ref = firebase_admin.db.reference(app.get_name() + '/' + device_dir)
AttributeError: 'module' object has no attribute 'db'
```