### PR TITLE
Refactor the testrunner

### DIFF
--- a/API/application/base.py
+++ b/API/application/base.py
@@ -21,8 +21,6 @@ class ApplicationBase(object):
     def __init__(self, name, cmd, options):
         self.name = name
         self.cmd = cmd
-        self.branch = options.branch
-        self.commit = options.commit
         self.buildtype = options.buildtype
 
     def get_name(self):

--- a/API/application/jerryscript.py
+++ b/API/application/jerryscript.py
@@ -32,30 +32,17 @@ class Application(base.ApplicationBase):
         '''
         return utils.join(paths.JERRY_BUILD_PATH, 'jerry')
 
+    def get_minimal_image(self):
+        '''
+        Return the path to the disable-features build.
+        '''
+        return utils.join(paths.JERRY_MINIMAL_BIN_PATH, 'jerry')
+
     def get_home_dir(self):
         '''
         Return the path to the application files.
         '''
         return paths.JERRY_APPS_PATH
-
-    def get_section_sizes(self):
-        '''
-        Returns the sizes of the main sections.
-        '''
-        jerry_bin = utils.join(paths.JERRY_MINIMAL_BIN_PATH, 'jerry')
-        utils.execute(paths.JERRY_PATH, 'arm-linux-gnueabi-strip', [jerry_bin])
-        sections, exit_code = utils.execute(paths.JERRY_PATH, 'arm-linux-gnueabi-size', ['-A', jerry_bin], quiet=True)
-
-        sizes = {}
-
-        for line in sections.splitlines():
-            for key in ['text', 'data', 'rodata', 'bss']:
-                if '.%s' % key in line:
-                    sizes[key] = line.split()[1]
-
-        sizes['total'] = utils.size(jerry_bin)
-
-        return sizes
 
     def get_install_dir(self):
         '''
@@ -83,18 +70,6 @@ class Application(base.ApplicationBase):
 
         return utils.join(paths.JERRY_PATH, 'nsh_romfsimg.h')
 
-    def update_repository(self):
-        '''
-        Update the repository to the given branch and commit.
-        '''
-        utils.execute(paths.JERRY_PATH, 'git', ['clean', '-dxf'])
-        utils.execute(paths.JERRY_PATH, 'git', ['reset', '--hard'])
-
-        utils.execute(paths.JERRY_PATH, 'git', ['fetch'])
-        utils.execute(paths.JERRY_PATH, 'git', ['checkout', self.branch])
-        utils.execute(paths.JERRY_PATH, 'git', ['pull', 'origin', self.branch])
-        utils.execute(paths.JERRY_PATH, 'git', ['checkout', self.commit])
-
     def build(self, device):
         '''
         Build IoT.js for the target device/OS and for Raspberry Pi 2.
@@ -103,8 +78,6 @@ class Application(base.ApplicationBase):
         # prebuild the OS
         os = device.get_os()
         os.prebuild(self)
-
-        self.update_repository()
 
         # Note: We should build JerryScript for Raspberry Pi 2, since the
         # binary size information (showed on the test-result webpages)
@@ -116,6 +89,8 @@ class Application(base.ApplicationBase):
         ]
 
         utils.execute(paths.JERRY_PATH, 'tools/build.py', minimal_build_flags)
+        utils.execute(paths.JERRY_PATH, 'arm-linux-gnueabi-strip',
+                                                    [self.get_minimal_image()])
 
         # The following builds are target specific with memory usage features.
         if device.get_type() == 'rpi2':

--- a/API/testrunner/testrunner.py
+++ b/API/testrunner/testrunner.py
@@ -83,7 +83,7 @@ class TestRunner(object):
 
         # Create the result.
         result = {
-            'bin' : app.get_section_sizes(),
+            'bin' : utils.get_section_sizes(app.get_minimal_image()),
             'date' : utils.get_standardized_date(),
             'tests' : self.results,
             'submodules' : submodules

--- a/driver.py
+++ b/driver.py
@@ -26,14 +26,8 @@ def parse_options():
     parser.add_argument('--app', choices=['iotjs', 'jerryscript'], default='iotjs',
                         help='the target application (default: %(default)s)')
 
-    parser.add_argument('--branch', metavar='name', default='master',
-                        help='an existing branch name for the app (default: %(default)s)')
-
     parser.add_argument('--buildtype', choices=['release', 'debug'], default='release',
                         help='buildtype for the os and the app (default: %(default)s)')
-
-    parser.add_argument('--commit', metavar='hash', default='HEAD',
-                        help='an existing hash within a branch (default: %(default)s)')
 
     parser.add_argument('--device', choices=['stm32f4dis', 'rpi2', 'artik053'], default='stm32f4dis',
                         help='indicate the device for testing (default: %(default)s)')
@@ -44,24 +38,24 @@ def parse_options():
     parser.add_argument('--timeout', metavar='sec', type=int, default=180,
                         help='timeout for tests (default: %(default)s sec)')
 
-    parser.add_argument('--remote-path', metavar='path',
+    group = parser.add_argument_group("SSH communication")
+
+    group.add_argument('--username', metavar='nick',
+                       help='username of the target device')
+
+    group.add_argument('--address', metavar='address',
+                        help='address of the target device (ip or ip:port)')
+
+    group.add_argument('--remote-path', metavar='path',
                         help='remote test folder on the device')
 
-    ssh_group = parser.add_argument_group("SSH communication")
+    group = parser.add_argument_group("Serial communication")
 
-    ssh_group.add_argument('--username', metavar='nick',
-                           help='username of the target device')
+    group.add_argument('--port', metavar='device',
+                       help='serial port name (e.g. /dev/ttyACM0 or /dev/ttyUSB0)')
 
-    ssh_group.add_argument('--address', metavar='address',
-                           help='address of the target device (ip or ip:port)')
-
-    serial_group = parser.add_argument_group("Serial communication")
-
-    serial_group.add_argument('--port', metavar='device',
-                              help='serial port name (e.g. /dev/ttyACM0 or /dev/ttyUSB0)')
-
-    serial_group.add_argument('--baud', metavar='baud', type=int, default=115200,
-                              help='baud rate (default: %(default)s)')
+    group.add_argument('--baud', metavar='baud', type=int, default=115200,
+                       help='baud rate (default: %(default)s)')
 
     return parser.parse_args()
 


### PR DESCRIPTION
* Moved `get_section_sizes` function (from iotjs.py and jerryscript.py) to the `utils.py` to eliminate code duplication.
* Implemented a `patch` function that patches the applications only if necessary. Added a revert mode to revert all the patches from the app projects (iotjs, jerry) at the end of the build. In this case there is no need to revert the memstat modifications (patches) with `git reset --hard`. 
* Removed `--commit` and `--branch` flags because they are not used.
* Did a minimal refactor in the argument parser.