### PR TITLE
Fixing some errors in case of JerryScript testrunner

### DIFF
--- a/API/application/base.py
+++ b/API/application/base.py
@@ -54,6 +54,12 @@ class ApplicationBase(object):
         '''
         raise NotImplementedError('Use the concrete subclasses.')
 
+    def get_image_stack(self):
+        '''
+        Return the path to the binary.
+        '''
+        raise NotImplementedError('Use the concrete subclasses.')
+
     def get_home_dir(self):
         '''
         Return the path to the application files.

--- a/API/application/jerryscript.py
+++ b/API/application/jerryscript.py
@@ -32,6 +32,12 @@ class Application(base.ApplicationBase):
         '''
         return utils.join(paths.JERRY_BUILD_PATH, 'jerry')
 
+    def get_image_stack(self):
+        '''
+        Return the path to the stack binary.
+        '''
+        return 0
+
     def get_minimal_image(self):
         '''
         Return the path to the disable-features build.
@@ -111,7 +117,7 @@ class Application(base.ApplicationBase):
             ]
             utils.execute(paths.JERRY_PATH, 'make', build_flags)
 
-        os.build(self, self.buildtype, 'all')
+        os.build(self, self.buildtype, [], 'all')
 
     def skip_test(self, test, os_name):
         '''

--- a/API/testrunner/testrunner.py
+++ b/API/testrunner/testrunner.py
@@ -203,13 +203,16 @@ class TestRunner(object):
                     stack_peak = result['stack_peak']
                     total_peak = utils.to_int(jerry_peak) + utils.to_int(malloc_peak) + utils.to_int(stack_peak)
 
-                    testresult['memory'] = {
-                        'jerry': jerry_peak,
-                        'malloc': malloc_peak,
-                        'stack': stack_peak,
-                        'total': total_peak
-                    }
-
+                    if app.get_name() == 'iotjs':
+                        testresult['memory'] = {
+                            'jerry': jerry_peak,
+                            'malloc': malloc_peak,
+                            'stack': stack_peak,
+                            'total': total_peak
+                        }
+                    # JerryScript supports only jerry-heap data.
+                    elif app.get_name() == 'jerryscript':
+                        testresult['memory'] = jerry_peak
                 else:
                     reporter.report_fail(test['name'])
                     testresult['result'] = 'fail'

--- a/resources/tester.py
+++ b/resources/tester.py
@@ -125,7 +125,12 @@ def run_jerry(options):
 
     output = output.rsplit("Heap stats",1)[0]
 
-    return { 'exitcode': exitcode, 'output': output, 'mempeak': mempeak }
+    return {
+        'exitcode': exitcode,
+        'output': output,
+        'jerry_peak_alloc': mempeak,
+        'malloc_peak': 'n/a'
+    }
 
 
 def run_iotjs(options):


### PR DESCRIPTION
JerryScript is not tested for several days because there were some issues introduced the iotjs memstat (malloc, jerry-heap, stack) development in js-remote-test.

This patch just a hotfix to be able to run JerryScript tests on stm32f4dis and rpi2.