### PR TITLE
Read all characters until the prompt in case of assertions or exceptions

### DIFF
--- a/API/device/artik053.py
+++ b/API/device/artik053.py
@@ -97,8 +97,7 @@ class Device(base.DeviceBase):
         # Send testrunner command to the device and process its result.
         self.serial.putc('%s %s\n' % (cmd, ' '.join(args).encode('utf8')))
         self.serial.readline()
-        message, stdout = self.serial.read_until(self.serial.get_prompt(),
-            'AssertionError', 'uncaughtException', 'arm_dataabort')
+        message, stdout = self.serial.read_until(self.serial.get_prompt(), 'arm_dataabort')
 
         exitcode = 1
         if message == self.serial.get_prompt():


### PR DESCRIPTION
Currently, the test system does not read the return value of the (iotjs) process if `uncaughtException` happens. The results of the tests (pass/fail) should be based on their return value. Since `test_process_exit.js` returns with zero, the test should be passed.

This patch reads the return value of the process (in case of `uncaughtException` as well) and uses that value as the test result.
