### PR TITLE
Do not wrap the memory consumption data in the testresult table

### DIFF
--- a/css/testruns.css
+++ b/css/testruns.css
@@ -245,6 +245,10 @@ html {
 		padding-right: 0;
 	}
 
+    .tests td:nth-child(3), .tests td:nth-child(4), .tests td:nth-child(5) {
+        white-space: nowrap;
+    }
+
 	.tests td, th {
 		border: 1px solid #eee;
 		padding: 0 8px;


### PR DESCRIPTION
Currently, the memory consumption data (e.g. 16680 B) are wrapped into more lines in the testresult table. This PR is a fix that helps to be they in one line.