### PR TITLE
Fix the layout of tooltip and remove information labels

### DIFF
--- a/css/c3.css
+++ b/css/c3.css
@@ -138,7 +138,8 @@
   margin-right: 6px; }
 
 .c3-tooltip td.value {
-  text-align: right; }
+  text-align: right;
+  font-family: monospace; }
 
 /*-- Area --*/
 .c3-area {

--- a/js/chart_settings.js
+++ b/js/chart_settings.js
@@ -40,7 +40,7 @@ function generate_chart(data, type, y_axis_min) {
 
   if (type === 'memory') {
     var type_key = 'average_memory';
-    var label_name = 'average memory (KB)';
+    var label_name = 'average memory consumption (KB)';
 
     var typedData = {
       json: data,
@@ -123,17 +123,15 @@ function generate_chart(data, type, y_axis_min) {
           '<tr class="c3-tooltip-name--binary">' +
             '<td class="name">' +
               '<span style="background-color: ' + color(d[0]) + '"></span>' +
-              d[0].name +
             '</td>' +
-            '<td class="value">' + ((d[0].value === null) ? 'N/A' : d[0].value.toFixed(1)) + '</td>' +
+            '<td class="value">' + ((d[0].value === null) ? 'n/a' : d[0].value.toFixed(1)) + ' KB</td>' +
           '</tr>';
           if (type === 'binary') {
             tt += '<tr class="c3-tooltip-name--binary">' +
             '<td class="name">' +
               '<span style="background-color: ' + color(d[1]) + '"></span>' +
-              d[1].name +
             '</td>' +
-            '<td class="value">' + ((d[1].value === null) ? 'N/A' : d[1].value.toFixed(1)) + '</td>' +
+            '<td class="value">' + ((d[1].value === null) ? 'n/a' : d[1].value.toFixed(1)) + ' KB</td>' +
           '</tr>';
           }
           tt += '<tr class="c3-tooltip-name--commit">' +


### PR DESCRIPTION
Replaced the default font family to `monospace` to make the values same sized (in the tool-tips). Removed the information labels in the tool-tips according to #78.