### PR TITLE
Simplify the stack measurement in case of RPi2 target.

### DIFF
--- a/API/application/base.py
+++ b/API/application/base.py
@@ -21,7 +21,6 @@ class ApplicationBase(object):
     def __init__(self, name, cmd, options):
         self.name = name
         self.cmd = cmd
-        self.cmd_stack = cmd + '_stack'
         self.buildtype = options.buildtype
 
     def get_name(self):
@@ -36,12 +35,6 @@ class ApplicationBase(object):
         '''
         return self.cmd
 
-    def get_cmd_stack(self):
-        '''
-        Return the command to run the application.
-        '''
-        return self.cmd_stack
-
     def get_section_sizes(self):
         '''
         Returns the sizes of the main sections.
@@ -49,12 +42,6 @@ class ApplicationBase(object):
         raise NotImplementedError('Use the concrete subclasses.')
 
     def get_image(self):
-        '''
-        Return the path to the binary.
-        '''
-        raise NotImplementedError('Use the concrete subclasses.')
-
-    def get_image_stack(self):
         '''
         Return the path to the binary.
         '''

--- a/API/application/iotjs.py
+++ b/API/application/iotjs.py
@@ -31,12 +31,6 @@ class Application(base.ApplicationBase):
         '''
         return utils.join(paths.IOTJS_BUILD_PATH, 'iotjs') % self.buildtype
 
-    def get_image_stack(self):
-        '''
-        Return the path to the stack binary.
-        '''
-        return utils.join(paths.IOTJS_BUILD_STACK_PATH, 'iotjs') % self.buildtype
-
     def get_target_profile_mapfile(self):
         '''
         Return the path to the target profile map file.
@@ -176,14 +170,13 @@ class Application(base.ApplicationBase):
 
         # Step 4: Create target specific profile with patches for the tests.
         self.__apply_heap_patches(device)
-
-        if device.get_type() in ['stm32f4dis', 'artik053']:
-            self.__apply_stack_patches(device)
+        self.__apply_stack_patches(device)
 
         os.prebuild(self)
 
         build_flags_heap = list(build_flags)
         build_flags_heap.append('--jerry-memstat')
+
         if device.get_type() == 'rpi2':
             build_flags_heap.append('--compile-flag=-g')
             build_flags_heap.append('--jerry-compile-flag=-g')
@@ -195,13 +188,6 @@ class Application(base.ApplicationBase):
 
         # Revert all the memstat patches from the project.
         self.__apply_heap_patches(device, revert=True)
-
-        # Build the application to stack consumption check
-        if device.get_type() == 'rpi2':
-            self.__apply_stack_patches(device)
-            build_flags.append('--builddir=%s' % paths.IOTJS_BUILD_STACK_DIR)
-            utils.execute(paths.IOTJS_PATH, 'tools/build.py', build_flags)
-
         self.__apply_stack_patches(device, revert=True)
 
 

--- a/API/application/jerryscript.py
+++ b/API/application/jerryscript.py
@@ -32,12 +32,6 @@ class Application(base.ApplicationBase):
         '''
         return utils.join(paths.JERRY_BUILD_PATH, 'jerry')
 
-    def get_image_stack(self):
-        '''
-        Return the path to the stack binary.
-        '''
-        return 0
-
     def get_minimal_image(self):
         '''
         Return the path to the disable-features build.

--- a/patches/iotjs-stack.diff
+++ b/patches/iotjs-stack.diff
@@ -1,5 +1,5 @@
 diff --git a/src/iotjs.c b/src/iotjs.c
-index 88a0bd4..d3c7bd3 100644
+index 88a0bd4..3f0d343 100644
 --- a/src/iotjs.c
 +++ b/src/iotjs.c
 @@ -28,6 +28,7 @@
@@ -23,7 +23,7 @@ index 88a0bd4..d3c7bd3 100644
    // Initialize debug print.
    init_debug_settings();
  
-@@ -257,3 +262,52 @@ terminate:;
+@@ -257,3 +262,62 @@ terminate:;
    }
    return ret_code;
  }
@@ -49,7 +49,6 @@ index 88a0bd4..d3c7bd3 100644
 +  }
 +
 +  printf("Stack usage: %d\n", (int) (stack_end_p - stack_p));
-+  exit(0);
 +}
 +
 +int __attribute__ ((noinline))
@@ -57,6 +56,7 @@ index 88a0bd4..d3c7bd3 100644
 +{
 +  uint8_t *stack_p;
 +  uint8_t *stack_end_p;
++  int ret_code;
 +
 +  argc = argc_;
 +  argv = argv_;
@@ -70,9 +70,19 @@ index 88a0bd4..d3c7bd3 100644
 +    stack_p++;
 +  }
 +
-+  __asm volatile ("mov sp, %0" : : "r" (stack_end_p));
++  // Save the current point of the stack pointer and
++  // modify that to point the custom stack.
++  __asm volatile ("mov %[orig_stack], sp;"
++                  "mov sp, %[custom_stack];"
++                  : [orig_stack] "=r" (stack_p)
++                  : [custom_stack] "r" (stack_end_p));
 +
-+  iotjs_entry_main();
++  ret_code = iotjs_entry_main();
++
++  // Restore the stack pointer to the original value.
++  __asm volatile ("mov sp, %0" : : "r" (stack_p));
++
 +  end_stack_measurement();
-+  return 0;
++
++  return ret_code;
 +}


### PR DESCRIPTION
On Linux (RPi2), a custom stack area is used to measure the stack consumption. Currently, the stack pointer is modified to point that array, but at the end of the JS execution, the stack pointer is not restored to the original (system) stack area, that results a crash in the engine.
That's why there are two IoT.js binaries created. One (without stack measure feature) is for testing, and one (with stack measure feature) is for the stack measurement.

In this patch I'd like to simplify the stack measurement in case of RPi2. This patch restores the stack pointer after the stack measurement, that eliminates the crashes. So now, it is enough to have only one IoT.js binary for testing on RPi2.