### PR TITLE
Update the iotjs-memstat.diff patch file

### DIFF
--- a/patches/iotjs-memstat.diff
+++ b/patches/iotjs-memstat.diff
@@ -13,10 +13,10 @@ index dd2c5b8..fb6567a 100644
      return iotjs_entry(argc, argv);
    }
 diff --git a/src/iotjs_util.c b/src/iotjs_util.c
-index be0e78f..5ef83e7 100644
+index 7d88973..8ea64c0 100644
 --- a/src/iotjs_util.c
 +++ b/src/iotjs_util.c
-@@ -63,21 +63,98 @@ iotjs_string_t iotjs_file_read(const char* path) {
+@@ -63,10 +63,73 @@ iotjs_string_t iotjs_file_read(const char* path) {
    return contents;
  }
  
@@ -90,12 +90,12 @@ index be0e78f..5ef83e7 100644
    return buffer;
  }
  
+@@ -85,11 +148,26 @@ char* iotjs_buffer_allocate_from_number_array(size_t size,
  
  char* iotjs_buffer_reallocate(char* buffer, size_t size) {
    IOTJS_ASSERT(buffer != NULL);
 -  return (char*)(realloc(buffer, size));
--}
- 
++
 +  size_t old_size;
 +  memcpy(&old_size, (buffer - SIZEOF_MM_ALLOCNODE), sizeof(size_t));
 +  mem_stat_free(old_size - SIZEOF_MM_ALLOCNODE);
@@ -107,7 +107,8 @@ index be0e78f..5ef83e7 100644
 +  mem_stat_alloc(new_size - SIZEOF_MM_ALLOCNODE);
 +
 +  return ptr;
-+}
+ }
+ 
  
  void iotjs_buffer_release(char* buffer) {
 +  size_t size;
@@ -118,7 +119,7 @@ index be0e78f..5ef83e7 100644
    free(buffer);
  }
 diff --git a/src/iotjs_util.h b/src/iotjs_util.h
-index e7e1896..607f836 100644
+index 14168c6..4e1ba64 100644
 --- a/src/iotjs_util.h
 +++ b/src/iotjs_util.h
 @@ -23,6 +23,10 @@
@@ -130,5 +131,5 @@ index e7e1896..607f836 100644
 +void print_mem_stat();
 +
  char* iotjs_buffer_allocate(size_t size);
- char* iotjs_buffer_reallocate(char* buffer, size_t size);
- void iotjs_buffer_release(char* buff);
+ char* iotjs_buffer_allocate_from_number_array(size_t size,
+                                               const jerry_value_t array);


### PR DESCRIPTION
The patch is outdated (could not be applied to IoT.js).