### PR TITLE
Modify the logging level in the lumpy (linker map handler) module

### DIFF
--- a/API/common/lumpy.py
+++ b/API/common/lumpy.py
@@ -42,7 +42,7 @@ import logging
 import json
 import re
 
-logging.basicConfig(level=logging.WARNING)
+logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)
 
 def load_map_data(filepath):


### PR DESCRIPTION
Currently, js-remote-test prints out a lot of warning messages from the lumpy module. This patch modifies the logging level to ERROR to hide these messages:

```
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_stext = ABSOLUTE (.)', 'address': '0x0000000008000000'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sinit = ABSOLUTE (.)', 'address': '0x0000000008098264'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_einit = ABSOLUTE (.)', 'address': '0x0000000008098264'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sdata = ABSOLUTE (.)', 'address': '0x0000000020000000'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sbss = ABSOLUTE (.)', 'address': '0x00000000200001f8'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_stext = ABSOLUTE (.)', 'address': '0x0000000008000000'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sinit = ABSOLUTE (.)', 'address': '0x00000000080ab790'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_einit = ABSOLUTE (.)', 'address': '0x00000000080ab790'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sdata = ABSOLUTE (.)', 'address': '0x0000000020000000'}'
WARNING:API.common.lumpy:Unable to connect symbol to object: '{'name': '_sbss = ABSOLUTE (.)', 'address': '0x00000000200002e8'}'
```