### PR TITLE
Make the binary size measurement more precise.

### DIFF
--- a/API/__init__.py
+++ b/API/__init__.py
@@ -60,7 +60,7 @@ def _resolve_symbols(env):
     '''
     Resolve all the symbols in the environment object.
 
-    "%%src/test/" -> /home/user/iotjs/test/
+    e.g. %iotjs/test/ -> /home/user/iotjs/test/
     '''
     for key, value in env.iteritems():
         env[key] = _resolve(value, env)
@@ -88,6 +88,14 @@ def _resolve(node, env):
     return node
 
 
+# Device - OS mapping.
+_targets = {
+    'stm32f4dis': 'nuttx',
+    'artik053': 'tizenrt',
+    'rpi2': 'linux'
+}
+
+
 def _replacer(string, env):
     '''
     Replace symbols with the corresponding string data.
@@ -95,7 +103,8 @@ def _replacer(string, env):
     if '%' not in string:
         return string
 
-    # These symbols always could be resolved.
+    # The following symbols are pre-defined, so their
+    # values are defined in this dictionary.
     symbol_mapping = {
         '%app': env['info']['app'],
         '%device': env['info']['device'],
@@ -104,15 +113,18 @@ def _replacer(string, env):
         '%result-path': paths.RESULT_PATH,
         '%build-path': paths.BUILD_PATH,
         '%patches': paths.PATCHES_PATH,
-        '%config': paths.CONFIG_PATH
+        '%config': paths.CONFIG_PATH,
+        '%target': _targets.get(env['info']['device'])
     }
 
     for symbol, value in symbol_mapping.items():
         string = string.replace(symbol, value)
 
     modules = env['modules']
-    # Process the remaining symbols that are
-    # reference to other modules.
+    # The following symbols are user defined that
+    # are references to other modules.
+    # e.g. %iotjs is replaced to the `src` member of
+    # the iotjs module.
     symbols = re.findall(r'%(.*?)/', string)
 
     for name in symbols:

--- a/API/builder/builder.py
+++ b/API/builder/builder.py
@@ -82,3 +82,16 @@ class BuilderBase(object):
 
         builder = builders.get(application['name'])
         builder(profile, extra_flags)
+
+    def _copy_build_files(self, target_module, builddir):
+        '''
+        Copy the created binaries, libs, linker map to the build folder.
+        '''
+        application = self.env['modules']['app']
+
+        linker_map = utils.join(builddir, 'linker.map')
+        lib_folder = utils.join(builddir, 'libs')
+
+        utils.copy(application['paths']['libdir'], lib_folder)
+        utils.copy(target_module['paths']['linker-map'], linker_map)
+        utils.copy(target_module['paths']['image'], builddir)

--- a/API/builder/targets/artik053.py
+++ b/API/builder/targets/artik053.py
@@ -33,10 +33,7 @@ class ARTIK053Builder(builder.BuilderBase):
         self._build_application(profile, use_extra_flags)
         self._build_tizenrt()
 
-        build_linker_map = utils.join(builddir, 'linker.map')
-        # Copy the linker map file and the image to the build folder.
-        utils.copy(tizenrt['paths']['linker-map'], build_linker_map)
-        utils.copy(tizenrt['paths']['image'], builddir)
+        self._copy_build_files(tizenrt, builddir)
 
     def _prebuild_tizenrt(self):
         '''

--- a/API/builder/targets/rpi2.py
+++ b/API/builder/targets/rpi2.py
@@ -32,10 +32,7 @@ class RPi2Builder(builder.BuilderBase):
         self._build_application(profile, use_extra_flags)
         self._build_freya()
 
-        build_linker_map = utils.join(builddir, 'linker.map')
-        # Copy the linker map file and the image to the build folder.
-        utils.copy(application['paths']['linker-map'], build_linker_map)
-        utils.copy(application['paths']['image'], builddir)
+        self._copy_build_files(application, builddir)
 
     def _build_freya(self):
         '''

--- a/API/builder/targets/stm32f4dis.py
+++ b/API/builder/targets/stm32f4dis.py
@@ -34,10 +34,7 @@ class STM32F4Builder(builder.BuilderBase):
         self._build_nuttx()
         self._build_stlink()
 
-        build_linker_map = utils.join(builddir, 'linker.map')
-        # Copy the linker map file and the image to the build folder.
-        utils.copy(nuttx['paths']['linker-map'], build_linker_map)
-        utils.copy(nuttx['paths']['image'], builddir)
+        self._copy_build_files(nuttx, builddir)
 
     def _prebuild_nuttx(self):
         '''

--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -89,6 +89,7 @@
         "minimal-profile": "%jerryscript/jerry-core/profiles/minimal.profile",
         "es2015-subset-profile": "%jerryscript/jerry-core/profiles/es2015-subset.profile",
         "linker-map": "%jerryscript/build/jerry-main/jerry.map",
+        "libdir": "%jerryscript/build/lib",
         "image": "%jerryscript/build/bin/jerry",
         "stm32f4dis-toolchain": "%jerryscript/cmake/toolchain_mcu_stm32f4.cmake",
         "artik053-toolchain": "%jerryscript/cmake/toolchain_mcu_artik053.cmake",
@@ -113,6 +114,7 @@
         "nuttx-profile": "%iotjs/test/profiles/nuttx.profile",
         "rpi2-profile": "%iotjs/test/profiles/rpi2-linux.profile",
         "linker-map": "%iotjs/build/arm-linux/%build-type/iotjs.map",
+        "libdir": "%iotjs/build/arm-%target/%build-type/lib",
         "image": "%iotjs/build/arm-linux/%build-type/bin/iotjs"
       },
       "patches": [


### PR DESCRIPTION
This patch saves IoT.js and JerryScript's static libraries in order to determine the list of the object files.
That list helps to process the linker map file more precisely.