### PR TITLE
Define the include paths correctly for the JerryScript build

### DIFF
--- a/API/builder/targets/artik053.py
+++ b/API/builder/targets/artik053.py
@@ -79,7 +79,7 @@ class ARTIK053Builder(builder.BuilderBase):
             '--mem-heap=70',
             '--profile=%s' % profiles[profile],
             '--toolchain=%s' % jerry['paths']['artik053-toolchain'],
-            '--compile-flag=-isystem %s' % tizenrt['paths']['include']
+            '--compile-flag="-isystem %s"' % tizenrt['paths']['include']
         ] + extra_flags
 
         # TizenRT requires the path of the used JerryScript folder.

--- a/API/builder/targets/stm32f4dis.py
+++ b/API/builder/targets/stm32f4dis.py
@@ -96,7 +96,8 @@ class STM32F4Builder(builder.BuilderBase):
             '--mem-heap=70',
             '--profile=%s' % profiles[profile],
             '--toolchain=%s' % jerry['paths']['stm32f4dis-toolchain'],
-            '--compile-flag=--sysroot=%s' % nuttx['src']
+            '--compile-flag=-I%s' % jerry['paths']['stm32f4dis-target'],
+            '--compile-flag="-isystem %s"' % nuttx['paths']['include']
         ] + extra_flags
 
         # NuttX requires the path of the used JerryScript folder.

--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -50,6 +50,7 @@
       "paths": {
         "tools": "%nuttx/tools/",
         "image": "%nuttx/nuttx.bin",
+        "include": "%nuttx/include",
         "linker-map": "%nuttx/arch/arm/src/nuttx.map"
       },
       "patches": [
@@ -92,6 +93,7 @@
         "linker-map": "%jerryscript/build/jerry-main/jerry.map",
         "libdir": "%jerryscript/build/lib",
         "image": "%jerryscript/build/bin/jerry",
+        "stm32f4dis-target": "%jerryscript/targets/nuttx-stm32f4",
         "stm32f4dis-toolchain": "%jerryscript/cmake/toolchain_mcu_stm32f4.cmake",
         "artik053-toolchain": "%jerryscript/cmake/toolchain_mcu_artik053.cmake",
         "rpi2-toolchain": "%jerryscript/cmake/toolchain_linux_armv7l.cmake"


### PR DESCRIPTION

TizenRT:
  * Defined the value of the compile-flag as string.

NuttXt:
  * Added an other include directory to the compiler-flags where Jerryscript's setjmp.h is defined for the target. If this is not defined, `setjmp.h` is from the `newlib` library, that is not correct.
  * Replaced `sysroot` to `isystem` because the `sysroot` usage was not correct. (`sysroot` is a prefix, `isystem` is a concrete folder.)