### PR TITLE
Replace --memstat to --mem-stats in case of IoT.js

### DIFF
--- a/API/resources/etc/tester.py
+++ b/API/resources/etc/tester.py
@@ -148,7 +148,7 @@ def run_iotjs(options):
     ]
 
     # 1. Run IoT.js without Freya to get its output and exit value.
-    output, exitcode = execute(options.cwd, options.cmd, ['--memstat', options.testfile])
+    output, exitcode = execute(options.cwd, options.cmd, ['--mem-stats', options.testfile])
 
     jerry_peak_alloc = 'n/a'
     stack_peak = 'n/a'

--- a/API/testrunner/devices/artik053.py
+++ b/API/testrunner/devices/artik053.py
@@ -100,7 +100,7 @@ class ARTIK053Device(object):
         testfile = '/rom/%s/%s' % (testset, test['name'])
 
         command = {
-            'iotjs': 'iotjs --memstat %s\n' % testfile,
+            'iotjs': 'iotjs --mem-stats %s\n' % testfile,
             'jerryscript': 'jerry %s --mem-stats\n' % testfile
         }
 

--- a/API/testrunner/devices/stm32f4dis.py
+++ b/API/testrunner/devices/stm32f4dis.py
@@ -103,7 +103,7 @@ class STM32F4Device(object):
         testfile = '/test/%s/%s' % (testset, test['name'])
 
         command = {
-            'iotjs': 'iotjs --memstat %s' % testfile,
+            'iotjs': 'iotjs --mem-stats %s' % testfile,
             'jerryscript': 'jerry %s --mem-stats' % testfile
         }
 


### PR DESCRIPTION
IoT.js has replaced the `--memstat` command line argument to `--mem-stats` in this [Pull request](https://github.com/Samsung/iotjs/pull/1514). That's why js-remote-test also should use the correct argument.