### PR TITLE
Fix the JerryScript build flags in case of NuttX and TizenRT

### DIFF
--- a/API/builder/targets/artik053.py
+++ b/API/builder/targets/artik053.py
@@ -79,7 +79,7 @@ class ARTIK053Builder(builder.BuilderBase):
             '--mem-heap=70',
             '--profile=%s' % profiles[profile],
             '--toolchain=%s' % jerry['paths']['artik053-toolchain'],
-            '--compile-flag="-isystem %s"' % tizenrt['paths']['include']
+            '--compile-flag=-isystem %s' % tizenrt['paths']['include']
         ] + extra_flags
 
         # TizenRT requires the path of the used JerryScript folder.

--- a/API/builder/targets/stm32f4dis.py
+++ b/API/builder/targets/stm32f4dis.py
@@ -97,7 +97,7 @@ class STM32F4Builder(builder.BuilderBase):
             '--profile=%s' % profiles[profile],
             '--toolchain=%s' % jerry['paths']['stm32f4dis-toolchain'],
             '--compile-flag=-I%s' % jerry['paths']['stm32f4dis-target'],
-            '--compile-flag="-isystem %s"' % nuttx['paths']['include']
+            '--compile-flag=-isystem %s' % nuttx['paths']['include']
         ] + extra_flags
 
         # NuttX requires the path of the used JerryScript folder.


### PR DESCRIPTION
Removed unnecessary quote characters from the build options. This is needed because GCC doesn't expect quote characters in its flag list. Without this patch, GCC uses newlib instead of NuttX or TizenRT as system library.
