### PR TITLE
Add missing module import for the ARTIK530 builder

### DIFF
--- a/API/builder/targets/artik530.py
+++ b/API/builder/targets/artik530.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from API.common import utils
+from API.common import paths, utils
 from API.builder import builder
 
 


### PR DESCRIPTION
The https://github.com/Samsung/js-remote-test/pull/121 PR removed a necessary module import before the Tizen binary size measurement patch (https://github.com/Samsung/js-remote-test/pull/124) landed.