### PR TITLE
Eliminiate dangerous default value

### DIFF
--- a/API/common/utils.py
+++ b/API/common/utils.py
@@ -30,10 +30,14 @@ class TimeoutException(Exception):
     pass
 
 
-def execute(cwd, cmd, args=[], quiet=False):
+def execute(cwd, cmd, args=None, quiet=False):
     '''
     Run the given command.
     '''
+
+    if args is None:
+        args = []
+
     stdout = None
     stderr = None
 


### PR DESCRIPTION
The list is a mutable default argument that will be shared beetween all invocations, so the value is not evaluated only once.

You can read more about the problem in this [relevant section](https://docs.python.org/3/tutorial/controlflow.html#default-argument-values) of the Python tutorial.