### PR TITLE
Add support for SSH port forwarding

### DIFF
--- a/API/common/reporter.py
+++ b/API/common/reporter.py
@@ -50,12 +50,13 @@ def report_configuration(env):
     console.log('  device:             %s' % info['device'])
     console.log('  timeout:            %s sec' % info['timeout'])
 
-    if info['device'] == 'rpi2':
-        console.log('  address:            %s' % info['address'])
+    if info['device'] in ['rpi2', 'artik530']:
+        console.log('  ip:                 %s' % info['ip'])
+        console.log('  port:               %s' % info['port'])
         console.log('  username:           %s' % info['username'])
         console.log('  remote workdir:     %s' % info['remote_workdir'])
     elif info['device'] in ['stm32f4dis', 'artik053']:
-        console.log('  port:               %s' % info['port'])
+        console.log('  device-id:          %s' % info['device_id'])
         console.log('  baud:               %d' % info['baud'])
 
 

--- a/API/testrunner/devices/artik053.py
+++ b/API/testrunner/devices/artik053.py
@@ -32,7 +32,7 @@ class ARTIK053Device(object):
         self.check_args()
 
         data = {
-            'port': env['info']['port'],
+            'dev-id': env['info']['device_id'],
             'baud': env['info']['baud'],
             'timeout': env['info']['timeout'],
             'prompt': 'TASH>>'
@@ -44,8 +44,8 @@ class ARTIK053Device(object):
         '''
         Check that all the arguments are established.
         '''
-        if not self.env['info']['port']:
-            console.fail('Please use the --port to select the device.')
+        if not self.env['info']['device_id']:
+            console.fail('Please use the --device-id to select the device.')
 
     def initialize(self):
         '''

--- a/API/testrunner/devices/artik530.py
+++ b/API/testrunner/devices/artik530.py
@@ -26,7 +26,8 @@ class ARTIK530Device(object):
         self.os = 'tizen'
         self.app = env['info']['app']
         self.user = env['info']['username']
-        self.address = env['info']['address']
+        self.ip = env['info']['ip']
+        self.port = env['info']['port']
         self.workdir = env['info']['remote_workdir']
         self.env = env
 
@@ -35,8 +36,9 @@ class ARTIK530Device(object):
 
         data = {
             'username': self.user,
-            'address': self.address,
-            'timeout': env['info']['timeout'],
+            'ip': self.ip,
+            'port': self.port,
+            'timeout': env['info']['timeout']
         }
 
         self.channel = SSHConnection(data)
@@ -47,7 +49,7 @@ class ARTIK530Device(object):
         '''
         if not self.workdir:
             console.fail('Please use --remote-workdir for the device.')
-        if not self.address:
+        if not self.ip:
             console.fail('Please define the IP address of the device.')
         if not self.user:
             console.fail('Please define the username of the device.')
@@ -80,13 +82,14 @@ class ARTIK530Device(object):
         # 2. Deploy the build folder to the device.
         self.login()
         self.channel.exec_command('mount -o remount,rw /')
-        rsync_flags = ['--recursive', '--compress', '--delete']
 
+        shell_flags = 'ssh -p %s' % self.port
+        rsync_flags = ['--rsh', shell_flags, '--recursive', '--compress', '--delete']
         # Note: slash character is required after the path.
         # In this case `rsync` copies the whole folder, not
         # the subcontents to the destination.
         src = self.env['paths']['build'] + '/'
-        dst = '%s@%s:%s' % (self.user, self.address, self.workdir)
+        dst = '%s@%s:%s' % (self.user, self.ip, self.workdir)
 
         utils.execute('.', 'rsync', rsync_flags + [src, dst])
 

--- a/API/testrunner/devices/connections/serialcom.py
+++ b/API/testrunner/devices/connections/serialcom.py
@@ -23,7 +23,7 @@ class SerialConnection(object):
     The serial communication wrapper.
     '''
     def __init__(self, device_info):
-        self.port = device_info['port']
+        self.id = device_info['dev-id']
         self.baud = device_info['baud']
         self.timeout = device_info['timeout']
 
@@ -34,7 +34,7 @@ class SerialConnection(object):
         '''
         Open the serial port.
         '''
-        self.serial = serial.Serial(self.port, self.baud, timeout=self.timeout)
+        self.serial = serial.Serial(port=self.id, baudrate=self.baud, timeout=self.timeout)
 
     def close(self):
         '''

--- a/API/testrunner/devices/connections/sshcom.py
+++ b/API/testrunner/devices/connections/sshcom.py
@@ -24,7 +24,8 @@ class SSHConnection(object):
     '''
     def __init__(self, device_info):
         self.username = device_info['username']
-        self.address = device_info['address']
+        self.ip = device_info['ip']
+        self.port = device_info['port']
         self.timeout = device_info['timeout']
 
         # Note: add your SSH key to the known host file
@@ -37,7 +38,7 @@ class SSHConnection(object):
         '''
         Open the serial port.
         '''
-        self.ssh.connect(self.address, username=self.username)
+        self.ssh.connect(hostname=self.ip, port=self.port, username=self.username)
 
     def close(self):
         '''

--- a/API/testrunner/devices/rpi2.py
+++ b/API/testrunner/devices/rpi2.py
@@ -26,7 +26,8 @@ class RPi2Device(object):
         self.os = 'linux'
         self.app = env['info']['app']
         self.user = env['info']['username']
-        self.address = env['info']['address']
+        self.ip = env['info']['ip']
+        self.port = env['info']['port']
         self.workdir = env['info']['remote_workdir']
         self.env = env
 
@@ -35,7 +36,8 @@ class RPi2Device(object):
 
         data = {
             'username': self.user,
-            'address': self.address,
+            'ip': self.ip,
+            'port': self.port,
             'timeout': env['info']['timeout']
         }
 
@@ -47,7 +49,7 @@ class RPi2Device(object):
         '''
         if not self.workdir:
             console.fail('Please use --remote-workdir for the device.')
-        if not self.address:
+        if not self.ip:
             console.fail('Please define the IP address of the device.')
         if not self.user:
             console.fail('Please define the username of the device.')
@@ -76,12 +78,13 @@ class RPi2Device(object):
         utils.copy(paths.FREYA_TESTER, build_path)
 
         # 2. Deploy the build folder to the device.
-        rsync_flags = ['--recursive', '--compress', '--delete']
+        shell_flags = 'ssh -p %s' % self.port
+        rsync_flags = ['--rsh', shell_flags, '--recursive', '--compress', '--delete']
         # Note: slash character is required after the path.
         # In this case `rsync` copies the whole folder, not
         # the subcontents to the destination.
         src = self.env['paths']['build'] + '/'
-        dst = '%s@%s:%s' % (self.user, self.address, self.workdir)
+        dst = '%s@%s:%s' % (self.user, self.ip, self.workdir)
 
         utils.execute('.', 'rsync', rsync_flags + [src, dst])
 

--- a/API/testrunner/devices/stm32f4dis.py
+++ b/API/testrunner/devices/stm32f4dis.py
@@ -32,7 +32,7 @@ class STM32F4Device(object):
         self.check_args()
 
         data = {
-            'port': env['info']['port'],
+            'dev-id': env['info']['device_id'],
             'baud': env['info']['baud'],
             'timeout': env['info']['timeout'],
             'prompt': 'nsh> '
@@ -44,8 +44,8 @@ class STM32F4Device(object):
         '''
         Check that all the arguments are established.
         '''
-        if not self.env['info']['port']:
-            console.fail('Please use the --port to select the device.')
+        if not self.env['info']['device_id']:
+            console.fail('Please use the --device-id to select the device.')
 
     def initialize(self):
         '''

--- a/README.md
+++ b/README.md
@@ -157,15 +157,18 @@ SSH communication:
 --username
   Defines the username for the Raspberry Pi target.
 
---address
+--ip
   IP(v4) address of the device.
+
+--port
+  Defines the SSH port. (default: 22)
 
 --remote-workdir
   Defines the working directory where the testing happens.
 
 Serial communication:
 
---port
+--device-id
   Defines the serial device id (e.g. /dev/ttyACM0)
 
 --baud

--- a/driver.py
+++ b/driver.py
@@ -71,9 +71,13 @@ def parse_options():
                        metavar='USER',
                        help='specify the username to login to the device.')
 
-    group.add_argument('--address',
+    group.add_argument('--ip',
                        metavar='IPADDR',
-                       help='specify the ip address of the device')
+                       help='specify the IP address of the device')
+
+    group.add_argument('--port',
+                       metavar='PORT', default=22, type=int,
+                       help='specify the SSH port (default: %(default)s)')
 
     group.add_argument('--remote-workdir',
                        metavar='PATH',
@@ -81,9 +85,9 @@ def parse_options():
 
     group = parser.add_argument_group("Serial communication")
 
-    group.add_argument('--port',
+    group.add_argument('--device-id',
                        metavar='DEVICE-ID',
-                       help='specify the port of the device (e.g. /dev/ttyACM0)')
+                       help='specify the device ID (e.g. /dev/ttyACM0)')
 
     group.add_argument('--baud',
                        type=int, default=115200,


### PR DESCRIPTION
This patch is useful if the host-pc and the device are on different network and SSH port forwarding is necessary to establish the communication.

* Modified the serial port related `--port` option to `--device-id`.
* Divided the secure shell related `--address` option into `--ip` and `--port`.

