### PR TITLE
Enable memory measurement in case of Tizen

### DIFF
--- a/API/builder/targets/rpi2.py
+++ b/API/builder/targets/rpi2.py
@@ -40,11 +40,6 @@ class RPi2Builder(builder.BuilderBase):
         '''
         freya = self.env['modules']['freya']
 
-        build_dir = utils.join(self.env['paths']['build'], 'valgrind_freya')
-        # Do not build if not necessary.
-        if utils.exists(build_dir):
-            return
-
         utils.define_environment('LD', 'arm-linux-gnueabihf-ld')
         utils.define_environment('AR', 'arm-linux-gnueabihf-ar')
         utils.define_environment('CC', 'arm-linux-gnueabihf-gcc')
@@ -55,6 +50,7 @@ class RPi2Builder(builder.BuilderBase):
 
         utils.execute(freya['src'], './autogen.sh')
         utils.execute(freya['src'], './configure', configure_options)
+        utils.execute(freya['src'], 'make', ['clean'])
         utils.execute(freya['src'], 'make', ['TOOLS=freya'])
 
         utils.unset_environment('LD')
@@ -63,6 +59,7 @@ class RPi2Builder(builder.BuilderBase):
         utils.unset_environment('CPP')
         utils.unset_environment('CXX')
 
+        build_dir = utils.join(self.env['paths']['build'], 'valgrind_freya')
         # Copy necessary files into the output directory.
         valgrind_files = [
             'vg-in-place',

--- a/API/resources/etc/iotjs-freya.config
+++ b/API/resources/etc/iotjs-freya.config
@@ -1,10 +1,10 @@
 - valgrind_freya
-- glibc-YOUR_GLIBC_VERSION/libio
+- glibc-%{glibc-version}/libio
 - jerry-core/jmem
 - jerry-core/parser/js/js-parser-mem.c
 - jerry-core/ecma/base/ecma-alloc.c
 
-iotjs     iotjs/src
+iotjs     %{iotjs-dirname}/src
 jerry     deps/jerry
 libtuv    deps/libtuv
 

--- a/API/resources/etc/tester.py
+++ b/API/resources/etc/tester.py
@@ -85,7 +85,7 @@ def execute(cwd, cmd, args=[]):
     output = process.communicate()[0]
     exitcode = process.returncode
 
-    return output, exitcode
+    return output.decode('utf-8'), exitcode
 
 
 def process_freya_output():
@@ -182,7 +182,7 @@ def run_iotjs(options):
     ldd_output, _ = execute(options.cwd, 'ldd', ['--version'])
     gnu_libc_version = ldd_output.splitlines()[0].split()[-1]
 
-    sed_options = ['-ie', 's/YOUR_GLIBC_VERSION/%s/g' % gnu_libc_version, 'iotjs-freya.config']
+    sed_options = ['-ie', 's/%%{glibc-version}/%s/g' % gnu_libc_version, 'iotjs-freya.config']
     execute(REMOTE_TESTRUNNER_PATH, 'sed', sed_options)
 
     # 3. Run IoT.js with Freya to create a log file with the memory information.

--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -3,7 +3,7 @@
     "stm32f4dis": ["nuttx", "nuttx-apps", "stlink"],
     "rpi2": ["freya"],
     "artik053": ["tizenrt"],
-    "artik530": []
+    "artik530": ["freya"]
   },
   "paths": {
     "result": "%{result-path}/%{app}/%{device}",
@@ -113,7 +113,7 @@
         "stm32f4dis": ["--jerry-memstat"],
         "rpi2": ["--jerry-memstat", "--compile-flag=-g", "--jerry-compile-flag=-g"],
         "artik053": ["--jerry-memstat"],
-        "artik530": [""]
+        "artik530": ["--jerry-memstat", "--compile-flag=-g", "--jerry-compile-flag=-g"]
       },
       "paths": {
         "tests": "%{iotjs}/test/",
@@ -131,8 +131,8 @@
         { "deps": ["artik053"], "file": "%{patches}/tizenrt-iotjs-stack.diff" },
         { "deps": ["stm32f4dis", "artik053"], "file": "%{patches}/iotjs-system-heap.diff" },
         { "deps": ["stm32f4dis", "artik053"], "file": "%{patches}/libtuv-system-heap.diff", "submodule": "%{iotjs}/deps/libtuv/" },
-        { "deps": ["stm32f4dis", "artik053", "rpi2"], "file": "%{patches}/jerryscript-jerry-heap.diff", "submodule": "%{iotjs}/deps/jerry/" },
-        { "deps": ["rpi2"], "file": "%{patches}/linux-iotjs-stack.diff" }
+        { "deps": ["stm32f4dis", "artik053", "rpi2", "artik530"], "file": "%{patches}/jerryscript-jerry-heap.diff", "submodule": "%{iotjs}/deps/jerry/" },
+        { "deps": ["rpi2", "artik530"], "file": "%{patches}/linux-iotjs-stack.diff" }
       ]
     },
     "freya": {

--- a/API/testrunner/devices/artik530.py
+++ b/API/testrunner/devices/artik530.py
@@ -77,7 +77,13 @@ class ARTIK530Device(object):
 
         # Copy all the tests into the build folder.
         utils.copy(test_src, test_dst)
-        utils.copy(paths.SIMPLE_TESTER, build_path)
+        utils.copy(paths.FREYA_CONFIG, build_path)
+        utils.copy(paths.FREYA_TESTER, build_path)
+
+        # Resolve the iotjs-dirname macro in the Freya configuration file.
+        basename = utils.basename(paths.GBS_IOTJS_PATH)
+        sed_flags = ['-i', 's/%%{iotjs-dirname}/%s/g' % basename, 'iotjs-freya.config']
+        utils.execute(build_path, 'sed', sed_flags)
 
         # 2. Deploy the build folder to the device.
         self.login()
@@ -117,14 +123,16 @@ class ARTIK530Device(object):
         '''
         self.login()
 
-        template = 'python3 %s/simpletester.py --cwd %s --cmd %s --testfile %s'
+        template = 'python3 %s/tester.py --cwd %s --cmd %s --testfile %s'
         # Absolute path to the test folder.
         testdir = '%s/test' % self.workdir
         # Absolute path to the test file.
         testfile = '%s/%s/%s' % (testdir, testset, test['name'])
+        # Absolute path to the application.
+        iotjs = '%s/iotjs' % self.workdir
 
         # Create the command that the device will execute.
-        command = template % (self.workdir, testdir, self.app, testfile)
+        command = template % (self.workdir, testdir, iotjs, testfile)
 
         stdout = self.channel.exec_command(command)
 

--- a/API/testrunner/devices/rpi2.py
+++ b/API/testrunner/devices/rpi2.py
@@ -77,6 +77,11 @@ class RPi2Device(object):
         utils.copy(paths.FREYA_CONFIG, build_path)
         utils.copy(paths.FREYA_TESTER, build_path)
 
+        # Resolve the iotjs-dirname macro in the Freya configuration file.
+        basename = utils.basename(target_app['src'])
+        sed_flags = ['-i', 's/%%{iotjs-dirname}/%s/g' % basename, 'iotjs-freya.config']
+        utils.execute(build_path, 'sed', sed_flags)
+
         # 2. Deploy the build folder to the device.
         shell_flags = 'ssh -p %s' % self.port
         rsync_flags = ['--rsh', shell_flags, '--recursive', '--compress', '--delete']
@@ -123,7 +128,6 @@ class RPi2Device(object):
         command = template % (self.workdir, testdir, apps[self.app], testfile)
 
         stdout = self.channel.exec_command(command)
-
         # Since the stdout is a JSON text, parse it.
         result = json.loads(stdout)
         # Make HTML friendly stdout.

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -24,6 +24,7 @@ sudo apt-get install -y autoconf libtool gperf flex bison autoconf2.13
 sudo apt-get install -y cmake libncurses-dev libusb-1.0-0-dev genromfs
 sudo apt-get install -y libsgutils2-dev gcc-arm-none-eabi minicom
 sudo apt-get install -y python-pip pkg-config libssl-dev
-sudo apt-get install -y gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabi
+sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-arm-linux-gnueabi
+sudo apt-get install -y binutils-arm-linux-gnueabi
 
 sudo pip install paramiko pyserial pyrebase


### PR DESCRIPTION
Enable the memory measurement in case of Tizen. There are some results on the [testresult webpage](https://samsung.github.io/iotjs-test-results/) that are created with this patch.

**Note**: There are some code duplications between the RPi and the Tizen target. After this pull request, I'd like to eliminate all the duplicated codes.


