### PR TITLE
Update the Tizen RPM package path

### DIFF
--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -12,7 +12,7 @@
     "build-test": "%{build-path}/%{app}/%{device}/%{build-type}/test",
     "build-target": "%{build-path}/%{app}/%{device}/%{build-type}/profiles/target",
     "build-minimal": "%{build-path}/%{app}/%{device}/%{build-type}/profiles/minimal",
-    "tizen-rpm-package": "%{home}/GBS-ROOT/local/repos/tizen_unified_preview1/armv7l/RPMS/%{app}-1.0.0-0.armv7l.rpm"
+    "tizen-rpm-package": "%{home}/GBS-ROOT/local/repos/tizen_unified_preview2/armv7l/RPMS/%{app}-1.0.0-0.armv7l.rpm"
   },
   "modules": {
     "stlink": {


### PR DESCRIPTION
Since the Tizen profile is updated in iotjs (https://github.com/Samsung/iotjs/commit/cf5fdc2bbc7869eebb4f1dd8dca7b809f677217d), js-remote-test should use the new profile name.