### PR TITLE
Fix system heap measurement on NuttX and TizenRT

### DIFF
--- a/API/resources/patches/iotjs-system-heap.diff
+++ b/API/resources/patches/iotjs-system-heap.diff
@@ -1,22 +1,22 @@
 diff --git a/src/iotjs.c b/src/iotjs.c
-index ef2be53..b490b36 100644
+index ef2be53..0720ec6 100644
 --- a/src/iotjs.c
 +++ b/src/iotjs.c
-@@ -251,6 +251,9 @@ exit:
-     iotjs_environment_release();
-     iotjs_debuglog_release();
+@@ -246,6 +246,9 @@ terminate:
+   iotjs_terminate(env);
  
-+    // Print mem-stat info.
-+    print_mem_stat();
+ exit:
++  // Print mem-stat info.
++  print_mem_stat();
 +
-     return iotjs_entry(argc, argv);
-   }
-
+   if (iotjs_environment_config(env)->debugger &&
+       iotjs_environment_config(env)->debugger->context_reset) {
+     iotjs_environment_release();
 diff --git a/src/iotjs_util.c b/src/iotjs_util.c
-index 3f9d248..0b47d40 100644
+index 243ee6b..103a505 100644
 --- a/src/iotjs_util.c
 +++ b/src/iotjs_util.c
-@@ -64,9 +64,73 @@ iotjs_string_t iotjs_file_read(const char* path) {
+@@ -66,9 +66,73 @@ iotjs_string_t iotjs_file_read(const char* path) {
  }
  
  
@@ -90,7 +90,7 @@ index 3f9d248..0b47d40 100644
    return buffer;
  }
  
-@@ -85,11 +149,26 @@ char* iotjs_buffer_allocate_from_number_array(size_t size,
+@@ -87,11 +151,26 @@ char* iotjs_buffer_allocate_from_number_array(size_t size,
  
  char* iotjs_buffer_reallocate(char* buffer, size_t size) {
    IOTJS_ASSERT(buffer != NULL);


### PR DESCRIPTION
System heap measurement is disabled in release mode, after the #135 update patch.  