### PR TITLE
Replace the python version for Tizen latest image

### DIFF
--- a/API/builder/targets/artik530.py
+++ b/API/builder/targets/artik530.py
@@ -108,7 +108,7 @@ class ARTIK530Builder(builder.BuilderBase):
         #       it will compile the IoT.js itself.
         utils.define_environment('IOTJS_BUILD_OPTION', iotjs_build_options)
 
-        utils.execute(iotjs['src'], 'config/tizen/gbsbuild.sh')
+        utils.execute(iotjs['src'], 'config/tizen/gbsbuild.sh', ['--clean'])
 
         tizen_build_dir = utils.join(paths.GBS_IOTJS_PATH, 'build')
         iotjs_build_dir = utils.join(iotjs['src'], 'build')

--- a/API/testrunner/devices/artik530.py
+++ b/API/testrunner/devices/artik530.py
@@ -123,7 +123,7 @@ class ARTIK530Device(object):
         '''
         self.login()
 
-        template = 'python3 %s/tester.py --cwd %s --cmd %s --testfile %s'
+        template = 'python %s/tester.py --cwd %s --cmd %s --testfile %s'
         # Absolute path to the test folder.
         testdir = '%s/tests' % self.workdir
         # Absolute path to the test file.

--- a/README.md
+++ b/README.md
@@ -82,19 +82,14 @@ Source:
 ### Set up ARTIK 530
 
 In case of the ARTIK 530 devices, the communication happens over `SSH`, like in case of RP2. You need to check a few things before starting remote-test.
-First, you must install rpm packages which are `openssh, python3, rsync` on the remote target. 
-([openssh](http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-unified_20171016.1/repos/standard/packages/armv7l/openssh-6.6p1-1.2.armv7l.rpm), 
-[libpython3](http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-base_20170929.1/repos/arm/packages/armv7l/libpython3_4m1_0-3.4.4-2.6.armv7l.rpm), 
-[python3-base](http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-base_20170929.1/repos/arm/packages/armv7l/python3-base-3.4.4-2.6.armv7l.rpm), 
-[python3](http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-base_20170929.1/repos/arm/packages/armv7l/python3-3.4.4-2.1.armv7l.rpm), 
-[rsync](http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-unified_20171016.1/repos/standard/packages/armv7l/rsync-3.1.1-2.1.armv7l.rpm))
 
-Download the packages above and install them with the commands below. To install them, serial port should be connected with the target board. For more details, please refer to [this link](https://developer.tizen.org/development/iot-preview/getting-started/flashing-tizen-images).
+First, you must install rpm packages which are `openssh`, `python`, `rsync` on the remote target. 
+To install them, you need sdb tool which is contained within tizen-studio. For more details, please refer to [this link](https://developer.tizen.org/development/tizen-studio/). After you have the sdb tool, install the packages with the commands below.
 
 ```sh
-# Assuming you are on the remote target.
-mount -o remount,rw /
-rpm -ivh <package_file_path>
+# The ARTIK530 board doesn't need to execute 'sdb connect` command.
+user@desktop $ ~/tizen-studio/tools/sdb connect <your-device-ip> 
+user@desktop $ ./tools/install_tizen_packages.sh
 ```
 
 Next, in order to avoid the authentication every time, you should create an ssh key (on your desktop) and share the public key with the device:
@@ -183,11 +178,11 @@ Serial communication:
 ```
 $ python driver.py --device stm32f4dis --app iotjs --port /dev/STM32F4 --baud 115200
 $ python driver.py --device stm32f4dis --app jerryscript --port /dev/STM32F4 --baud 115200
-$ python driver.py --device rpi2 --app iotjs --address a.b.c.d --username pi --remote-workdir /home/pi/testrunner
-$ python driver.py --device rpi2 --app jerryscript --address a.b.c.d --username pi --remote-workdir /home/pi/testrunner
+$ python driver.py --device rpi2 --app iotjs --ip a.b.c.d --username pi --remote-workdir /home/pi/testrunner
+$ python driver.py --device rpi2 --app jerryscript --ip a.b.c.d --username pi --remote-workdir /home/pi/testrunner
 $ python driver.py --device artik053 --app iotjs --port /dev/ARTIK053 --baud 115200
 $ python driver.py --device artik053 --app jerryscript --port /dev/ARTIK053 --baud 115200
-$ python driver.py --device artik530 --app iotjs --address a.b.c.d --username root --remote-workdir /root/testrunner
+$ python driver.py --device artik530 --app iotjs --ip a.b.c.d --username root --remote-workdir /root/testrunner
 ```
 
 All the results are written into JSON files that are found in a `results` folder. Name of the output files are datetime with the following format:

--- a/tools/install_tizen_packages.sh
+++ b/tools/install_tizen_packages.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2018-present Samsung Electronics Co., Ltd. and other contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SDB=$HOME'/tizen-studio/tools/sdb' # check your tizen-studio path
+
+DEVICES=`sdb devices | wc -l`;
+
+if [ $DEVICES != 2 ]
+then
+  echo "Please connect sdb to device"
+  echo ""
+  exit
+fi
+
+# Initialize device
+$SDB root on
+$SDB shell mount -o rw,remount /
+
+# Download packages
+PACKAGES_DIR='packages'
+mkdir $PACKAGES_DIR
+wget -P $PACKAGES_DIR http://download.tizen.org/snapshots/tizen/base/tizen-base_20180420.1/repos/standard/packages/armv7l/db4-4.8.30.NC-3.250.armv7l.rpm
+wget -P $PACKAGES_DIR http://download.tizen.org/snapshots/tizen/base/tizen-base_20180420.1/repos/standard/packages/armv7l/libpython-2.7.8-4.33.armv7l.rpm
+wget -P $PACKAGES_DIR http://download.tizen.org/snapshots/tizen/base/tizen-base_20180420.1/repos/standard/packages/armv7l/python-2.7.8-4.33.armv7l.rpm
+wget -P $PACKAGES_DIR http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-unified_20171016.1/repos/standard/packages/armv7l/openssh-6.6p1-1.2.armv7l.rpm
+wget -P $PACKAGES_DIR http://download.tizen.org/releases/previews/iot/preview1/tizen-4.0-unified_20171016.1/repos/standard/packages/armv7l/rsync-3.1.1-2.1.armv7l.rpm
+
+# Push packages file to device and install them.
+$SDB push $PACKAGES_DIR/*.rpm /tmp/
+$SDB shell rpm -Uvh --force --nodeps /tmp/*.rpm
+
+rm -rf $PACKAGES_DIR


### PR DESCRIPTION
I found some issues with python3 in the latest Tizen image. I change it to 2.x version.
I also add that gbs builds cleanly.

JSRemoteTest-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com