### PR TITLE
Ensure that the build type is debug in case of coverage measurement

### DIFF
--- a/API/builder/targets/artik530.py
+++ b/API/builder/targets/artik530.py
@@ -112,7 +112,12 @@ class ARTIK530Builder(builder.BuilderBase):
         #       it will compile the IoT.js itself.
         utils.define_environment('IOTJS_BUILD_OPTION', iotjs_build_options)
 
-        utils.execute(iotjs['src'], 'config/tizen/gbsbuild.sh', ['--clean'])
+        args = ['--clean']
+
+        if self.env['info']['buildtype'] == 'debug':
+            args.append('--debug')
+
+        utils.execute(iotjs['src'], 'config/tizen/gbsbuild.sh', args)
 
         tizen_build_dir = utils.join(paths.GBS_IOTJS_PATH, 'build')
         iotjs_build_dir = utils.join(iotjs['src'], 'build')

--- a/driver.py
+++ b/driver.py
@@ -106,6 +106,16 @@ def main():
     '''
     options = parse_options()
 
+    if options.coverage:
+        if options.app != 'iotjs':
+            print('Warning! Coverage measurement is only supported with IoT.js!')
+            options.coverage = None
+        elif options.buildtype != 'debug':
+            print('Warning! Coverage measurement is only supported with debug build type!')
+            # Overwrite the buildtype option to debug.
+            # In IoT.js the code is minimized in release mode, which will mess up the line numbers.
+            options.buildtype = 'debug'
+
     # Get an environment object that holds all the necessary
     # information for the build and the test.
     env = API.load_testing_environment(options)


### PR DESCRIPTION
In IoT.js the code is minimized with release mode, which will mess up the line numbers.