### PR TITLE
Do not copy the dynamicmodule.iotjs shared lib to the test folder

### DIFF
--- a/API/builder/builder.py
+++ b/API/builder/builder.py
@@ -91,12 +91,7 @@ class BuilderBase(object):
 
         linker_map = utils.join(builddir, 'linker.map')
         lib_folder = utils.join(builddir, 'libs')
-        dynamic_folder = utils.join(builddir, 'test')
 
         utils.copy(application['paths']['libdir'], lib_folder)
-
-        if application == 'iotjs':
-            utils.copy(application['paths']['dynamic-module-test'], dynamic_folder)
-
         utils.copy(target_module['paths']['linker-map'], linker_map)
         utils.copy(target_module['paths']['image'], builddir)

--- a/API/resources/etc/tester.py
+++ b/API/resources/etc/tester.py
@@ -156,9 +156,6 @@ def run_iotjs(options):
         options.testfile
     ]
 
-    # The test_module_dynamicload.js file requires to define the dynamic module test path.
-    os.environ['IOTJS_PATH'] = os.path.join(REMOTE_TESTRUNNER_PATH, 'test')
-
     args = ['--mem-stats']
 
     if options.coverage_port:

--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -128,7 +128,6 @@
         "libdir": "%{iotjs}/build/%{target}/%{build-type}/lib",
         "image": "%{iotjs}/build/%{target}/%{build-type}/bin/iotjs",
         "coverage-client": "%{iotjs}/deps/jerry/jerry-debugger/jerry-client-ws.py",
-        "dynamic-module-test": "%{iotjs}/build/%{target}/%{build-type}/test",
         "js-sources" : "%{iotjs}/src/js/"
       },
       "patches": [


### PR DESCRIPTION
After https://github.com/Samsung/iotjs/pull/1639 land, it doesn't need to copy the dynamicmodule.iotjs to the test folder, because the test folder will be the default place for that.