### PR TITLE
Update the Tizen RPM package path.

### DIFF
--- a/API/resources/resources.json
+++ b/API/resources/resources.json
@@ -12,7 +12,7 @@
     "build-test": "%{build-path}/%{app}/%{device}/%{build-type}/test",
     "build-target": "%{build-path}/%{app}/%{device}/%{build-type}/profiles/target",
     "build-minimal": "%{build-path}/%{app}/%{device}/%{build-type}/profiles/minimal",
-    "tizen-rpm-package": "%{home}/GBS-ROOT/local/repos/tizen_unified_preview2/armv7l/RPMS/%{app}-1.0.0-0.armv7l.rpm"
+    "tizen-rpm-package": "%{home}/GBS-ROOT/local/repos/tizen_unified_m1/armv7l/RPMS/%{app}-1.0.0-0.armv7l.rpm"
   },
   "modules": {
     "stlink": {

--- a/API/testrunner/devices/device_base.py
+++ b/API/testrunner/devices/device_base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import time
 
 from API.common import console, utils, paths
 from threading import Thread
@@ -98,6 +99,7 @@ class RemoteDevice(object):
             buildinfo = '/test/tools/iotjs_build_info.js'
             command = 'iotjs %s' % buildinfo
 
+        self.reset()
         self.login()
 
         output = self.channel.exec_command(command)


### PR DESCRIPTION
The Tizen profile was changed from `tizen_unified_preview2` to `tizen_unified_m1` in IoT.js (https://github.com/Samsung/iotjs/pull/1670). This patch also has some unrelated fixes.