### PR TITLE
Always initialize the wi-fi module on the TizenRT target.

### DIFF
--- a/API/testrunner/devices/device_base.py
+++ b/API/testrunner/devices/device_base.py
@@ -67,10 +67,10 @@ class RemoteDevice(object):
                 self.channel.exec_command('\n\n')
                 self.channel.exec_command('cd /test')
 
-                if self.env['info']['coverage'] and self.app == 'iotjs':
+                if self.device == 'artik053' and self.app == 'iotjs':
                     # Set up the wifi connection.
-                    wifi_name = utils.get_environment('ARTIK_COV_WIFI_NAME')
-                    wifi_pwd =  utils.get_environment('ARTIK_COV_WIFI_PWD')
+                    wifi_name = utils.get_environment('ARTIK_WIFI_NAME')
+                    wifi_pwd =  utils.get_environment('ARTIK_WIFI_PWD')
 
                     self.channel.exec_command('wifi startsta')
                     self.channel.exec_command('wifi join %s %s' % (wifi_name, wifi_pwd))

--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Every JSON file contain information about the test results (status, output, memo
 You are able to run coverage measurement on ARTIK053. A modified jerry-debugger is used to calculate the covered JS source lines, so it needs to specify a unique network address for the connection with the `coverage` option. ARTIK053 uses wifi for the communication, so it also needs to set the following environment variables:
 
 ```
-export ARTIK_COV_WIFI_NAME=your_wifi_name
-export ARTIK_COV_WIFI_PWD=your_wifi_password
+export ARTIK_WIFI_NAME=your_wifi_name
+export ARTIK_WIFI_PWD=your_wifi_password
 ```
 
 To run tests with coverage:


### PR DESCRIPTION
The HTTPS tests of IoT.js require Internet connection. So the wi-fi should always be initialized, not only when coverage is used.