### PR TITLE
Turn on Mosquitto in testrunner.py for local server usage

### DIFF
--- a/API/testrunner/testrunner.py
+++ b/API/testrunner/testrunner.py
@@ -47,6 +47,8 @@ class TestRunner(object):
         # Flash the device to be able to run the tests.
         self.device.initialize()
         self.skiplist = Skiplist(environment, self.device)
+        
+        utils.execute('.', 'mosquitto', ['-d'])
 
     def run(self):
         '''

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -26,5 +26,6 @@ sudo apt-get install -y libsgutils2-dev gcc-arm-none-eabi minicom
 sudo apt-get install -y python-pip pkg-config libssl-dev
 sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-arm-linux-gnueabi
 sudo apt-get install -y binutils-arm-linux-gnueabi
+sudo apt-get install -y mosquitto
 
 sudo pip install paramiko pyserial pyrebase


### PR DESCRIPTION
Turning on a Mosquitto in `testrunner.py,` because after https://github.com/Samsung/iotjs/pull/1689 a local server will be needed. Also added Mosquitto to `install-deps.sh` since it's now part of the `testrunner.py`.

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu