### PR TITLE
Set the current datetime on TizenRT.

### DIFF
--- a/jstest/builder/utils.py
+++ b/jstest/builder/utils.py
@@ -42,7 +42,7 @@ def create_build_info(env):
 
     # Merge the collected values into a result object.
     build_info = {
-        'build-date': utils.get_standardized_date(),
+        'build-date': utils.current_date('%Y-%m-%dT%H.%M.%SZ'),
         'last-commit-date': submodules[app_name]['date'],
         'bin': bin_sizes,
         'submodules': submodules

--- a/jstest/common/utils.py
+++ b/jstest/common/utils.py
@@ -355,11 +355,11 @@ def last_commit_info(gitpath):
     return info
 
 
-def get_standardized_date():
+def current_date(format):
     '''
-    Get the current date in standardized format.
+    Format the current datetime by the given pattern.
     '''
-    return time.strftime('%Y-%m-%dT%H.%M.%SZ')
+    return time.strftime(format)
 
 
 def process_output(output):

--- a/jstest/testrunner/devices/device_base.py
+++ b/jstest/testrunner/devices/device_base.py
@@ -75,6 +75,12 @@ class RemoteDevice(object):
                     self.channel.exec_command('wifi startsta')
                     self.channel.exec_command('wifi join %s %s' % (wifi_name, wifi_pwd))
                     self.channel.exec_command('ifconfig wl1 dhcp')
+
+                    # Set the current date and time on the device.
+                    # Note: test_tls_ca.js requires the current datetime.
+                    datetime = utils.current_date('%b %d %H:%M:%S %Y')
+                    self.channel.exec_command('date -s %s' % datetime)
+
                     time.sleep(1)
 
         except Exception as e:


### PR DESCRIPTION
This patch initializes the device with the current date. (The date is `Jan 01 00:00:00 2010` after every restart so it needs to be updated). `test_tls_ca.js` requires the current date-time because the certificate has date information.
