### PR TITLE
Move leftout functions from API/common/utils.py

### DIFF
--- a/jstest/builder/builder.py
+++ b/jstest/builder/builder.py
@@ -16,7 +16,7 @@ from abc import ABCMeta, abstractmethod
 
 from jstest import resources
 from jstest.common import utils
-from jstest.builder import utils as builderUtils
+from jstest.builder import utils as builder_utils
 
 
 class BuilderBase(object):
@@ -69,7 +69,7 @@ class BuilderBase(object):
         self._build('minimal', paths['build-minimal'])
         self._build('target', paths['build-target'])
 
-        builderUtils.create_build_info(self.env)
+        builder_utils.create_build_info(self.env)
 
     def create_test_build(self):
         '''

--- a/jstest/builder/targets/stm32f4dis.py
+++ b/jstest/builder/targets/stm32f4dis.py
@@ -14,7 +14,7 @@
 
 from jstest.builder import builder
 from jstest.common import utils
-
+from jstest.builder import utils as builder_utils
 
 class STM32F4Builder(builder.BuilderBase):
     '''
@@ -143,4 +143,4 @@ class STM32F4Builder(builder.BuilderBase):
         tests = target_app['paths']['tests']
         romfs = nuttx_apps['paths']['romfs']
         # Override the default ROMFS file of NuttX.
-        utils.generate_romfs(tests, romfs)
+        builder_utils.generate_romfs(tests, romfs)

--- a/jstest/builder/utils.py
+++ b/jstest/builder/utils.py
@@ -12,7 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from jstest.common import utils
+from jstest.builder import lumpy
+
+
+_LIBLIST = [
+    'libhttpparser.a',
+    'libiotjs.a',
+    'libjerry-core.a',
+    'libjerry-ext.a',
+    'libjerry-port-default.a',
+    'libjerry-port-default-minimal.a',
+    'libtuv.a'
+]
+
 
 def create_build_info(env):
     '''
@@ -26,8 +41,8 @@ def create_build_info(env):
     target_builddir = env['paths']['build-target']
 
     bin_sizes = {
-        'minimal-profile': utils.calculate_section_sizes(minimal_builddir),
-        'target-profile': utils.calculate_section_sizes(target_builddir)
+        'minimal-profile': calculate_section_sizes(minimal_builddir),
+        'target-profile': calculate_section_sizes(target_builddir)
     }
 
     # Git commit information from the projects.
@@ -49,3 +64,75 @@ def create_build_info(env):
     }
 
     utils.write_json_file(utils.join(build_path, 'build.json'), build_info)
+
+
+def generate_romfs(src, dst):
+    '''
+    Create a romfs_img from the source directory that is
+    converted to a header (byte array) file. Finally, add
+    a `const` modifier to the byte array to be the data
+    in the Read Only Memory.
+    '''
+    romfs_img = utils.join(os.curdir, 'romfs_img')
+
+    utils.execute(os.curdir, 'genromfs', ['-f', romfs_img, '-d', src])
+    utils.execute(os.curdir, 'xxd', ['-i', 'romfs_img', dst])
+    utils.execute(os.curdir, 'sed', ['-i', 's/unsigned/const\ unsigned/g', dst])
+
+    os.remove(romfs_img)
+
+
+def calculate_section_sizes(builddir):
+    '''
+    Return the sizes of the main sections.
+    '''
+    section_sizes = {
+        'bss': 0,
+        'text': 0,
+        'data': 0,
+        'rodata': 0
+    }
+
+    mapfile = utils.join(builddir, 'linker.map')
+    libdir = utils.join(builddir, 'libs')
+
+    if not (utils.exists(mapfile) and utils.exists(libdir)):
+        return section_sizes
+
+    # Get the names of the object files that the static
+    # libraries (libjerry-core.a, ...) have.
+    objlist = read_objects_from_libs(libdir, _LIBLIST)
+
+    raw_data = lumpy.load_map_data(mapfile)
+    sections = lumpy.parse_to_sections(raw_data)
+    # Extract .rodata section from the .text section.
+    lumpy.hoist_section(sections, '.text', '.rodata')
+
+    for section in sections:
+        section_name = section['name'][1:]
+        # Skip sections that are not relevant.
+        if section_name not in section_sizes.keys():
+            continue
+
+        for entry in section['contents']:
+            if any(obj in entry['path'] for obj in objlist):
+                section_sizes[section_name] += entry['size']
+
+    return section_sizes
+
+
+def read_objects_from_libs(libpath, liblist):
+    '''
+    Read all the names of the object files that are
+    located in the archive files.
+    '''
+    objlist = []
+
+    for object_file in os.listdir(libpath):
+        if object_file not in liblist:
+            continue
+
+        output, _ = utils.execute(libpath, 'ar', ['t', object_file], quiet=True)
+        objlist.extend(output.splitlines())
+
+    return objlist

--- a/jstest/common/utils.py
+++ b/jstest/common/utils.py
@@ -22,7 +22,6 @@ import time
 from jstest.common import console, paths
 from jstest.builder import lumpy
 
-
 class TimeoutException(Exception):
     '''
     Custom exception in case of timeout.
@@ -34,11 +33,14 @@ def execute(cwd, cmd, args=None, quiet=False, strict=True):
     '''
     Run the given command.
     '''
+
     if args is None:
         args = []
 
     stdout = None
     stderr = None
+
+    console.info("Run: %s %s (%s)\n" % (cmd, ' '.join(args), cwd))
 
     if quiet or os.environ.get('QUIET', ''):
         stdout = subprocess.PIPE
@@ -225,7 +227,6 @@ def exists(path):
     '''
     return os.path.exists(path)
 
-
 def exist_files(path, files):
     '''
     Checks that all files in the list exist relative to the given path.
@@ -235,7 +236,6 @@ def exist_files(path, files):
             return False
 
     return True
-
 
 def size(binary):
     '''
@@ -297,7 +297,7 @@ def remove_file(filename):
         pass
 
 
-_LIBLIST = [
+_liblist = [
     'libhttpparser.a',
     'libiotjs.a',
     'libjerry-core.a',
@@ -327,7 +327,7 @@ def calculate_section_sizes(builddir):
 
     # Get the names of the object files that the static
     # libraries (libjerry-core.a, ...) have.
-    objlist = read_objects_from_libs(libdir, _LIBLIST)
+    objlist = read_objects_from_libs(libdir, _liblist)
 
     raw_data = lumpy.load_map_data(mapfile)
     sections = lumpy.parse_to_sections(raw_data)
@@ -378,11 +378,11 @@ def last_commit_info(gitpath):
     return info
 
 
-def current_date(date_format):
+def current_date(format):
     '''
     Format the current datetime by the given pattern.
     '''
-    return time.strftime(date_format)
+    return time.strftime(format)
 
 
 def process_output(output):

--- a/jstest/testrunner/devices/artik053.py
+++ b/jstest/testrunner/devices/artik053.py
@@ -18,6 +18,7 @@ from threading import Thread
 from jstest.testrunner.devices.device_base import RemoteDevice
 from jstest.common import utils
 from jstest.testrunner.devices.connections.serialcom import SerialConnection
+from jstest.testrunner import utils as testrunner_utils
 
 class ARTIK053Device(RemoteDevice):
     '''
@@ -74,7 +75,7 @@ class ARTIK053Device(RemoteDevice):
 
         if self.env['info']['coverage']:
             args.append('--start-debug-server')
-            port = utils.read_port_from_url(self.env['info']['coverage'])
+            port = testrunner_utils.read_port_from_url(self.env['info']['coverage'])
             args.append('--debug-port %s' % port)
 
         command = {
@@ -88,7 +89,7 @@ class ARTIK053Device(RemoteDevice):
 
         if self.env['info']['coverage'] and self.app == 'iotjs':
             # Start the client script on a different thread for coverage.
-            client_thread = Thread(target=utils.run_coverage_script, kwargs={'env': self.env})
+            client_thread = Thread(target=testrunner_utils.run_coverage_script, kwargs={'env': self.env})
             client_thread.daemon = True
             client_thread.start()
 
@@ -97,7 +98,7 @@ class ARTIK053Device(RemoteDevice):
         if message == 'arm_dataabort':
             output += self.channel.readline().replace('\r\n', '')
 
-        stdout, memstat, exitcode = utils.process_output(output)
+        stdout, memstat, exitcode = testrunner_utils.process_output(output)
 
         self.logout()
 

--- a/jstest/testrunner/devices/artik530.py
+++ b/jstest/testrunner/devices/artik530.py
@@ -17,6 +17,7 @@ from threading import Thread
 
 from jstest.testrunner.devices.device_base import RemoteDevice
 from jstest.common import utils, paths
+from jstest.testrunner import utils as testrunner_utils
 from jstest.testrunner.devices.connections.sshcom import SSHConnection
 
 class ARTIK530Device(RemoteDevice):
@@ -110,11 +111,11 @@ class ARTIK530Device(RemoteDevice):
             command += ' --no-memstat'
 
         if self.env['info']['coverage'] and self.app == 'iotjs':
-            port = utils.read_port_from_url(self.env['info']['coverage'])
+            port = testrunner_utils.read_port_from_url(self.env['info']['coverage'])
             command += ' --coverage-port %s' % port
 
             # Start the client script on a different thread for coverage.
-            client_thread = Thread(target=utils.run_coverage_script, kwargs={'env': self.env})
+            client_thread = Thread(target=testrunner_utils.run_coverage_script, kwargs={'env': self.env})
             client_thread.daemon = True
             client_thread.start()
 

--- a/jstest/testrunner/devices/device_base.py
+++ b/jstest/testrunner/devices/device_base.py
@@ -16,6 +16,7 @@ import json
 import time
 
 from jstest.common import console, utils
+from jstest.testrunner import utils as testrunner_utils
 
 class RemoteDevice(object):
     '''
@@ -114,7 +115,7 @@ class RemoteDevice(object):
 
         output = self.channel.exec_command(command)
         # Process the output to get the json string and the exitcode.
-        build_info, _, exitcode = utils.process_output(output)
+        build_info, _, exitcode = testrunner_utils.process_output(output)
 
         if exitcode != 0:
             console.fail('%s returned with exitcode %d' % (buildinfo, exitcode))

--- a/jstest/testrunner/devices/rpi2.py
+++ b/jstest/testrunner/devices/rpi2.py
@@ -17,6 +17,7 @@ from threading import Thread
 
 from jstest.testrunner.devices.device_base import RemoteDevice
 from jstest.common import utils, paths
+from jstest.testrunner import utils as testrunner_utils
 from jstest.testrunner.devices.connections.sshcom import SSHConnection
 
 class RPi2Device(RemoteDevice):
@@ -103,11 +104,11 @@ class RPi2Device(RemoteDevice):
             command += ' --no-memstat'
 
         if self.env['info']['coverage'] and self.app == 'iotjs':
-            port = utils.read_port_from_url(self.env['info']['coverage'])
+            port = testrunner_utils.read_port_from_url(self.env['info']['coverage'])
             command += ' --coverage-port %s' % port
 
             # Start the client script on a different thread for coverage.
-            client_thread = Thread(target=utils.run_coverage_script, kwargs={'env' :self.env})
+            client_thread = Thread(target=testrunner_utils.run_coverage_script, kwargs={'env' :self.env})
             client_thread.daemon = True
             client_thread.start()
 

--- a/jstest/testrunner/devices/stm32f4dis.py
+++ b/jstest/testrunner/devices/stm32f4dis.py
@@ -15,6 +15,7 @@
 import time
 
 from jstest.common import utils
+from jstest.testrunner import utils as testrunner_utils
 from jstest.testrunner.devices.device_base import RemoteDevice
 from jstest.testrunner.devices.connections.serialcom import SerialConnection
 
@@ -83,7 +84,7 @@ class STM32F4Device(RemoteDevice):
         # Run the test on the device.
         output = self.channel.exec_command(command[self.app])
 
-        stdout, memstat, _ = utils.process_output(output)
+        stdout, memstat, _ = testrunner_utils.process_output(output)
         # Process the exitcode of the last command.
         exitcode = self.channel.exec_command('echo $?')
 

--- a/jstest/testrunner/testrunner.py
+++ b/jstest/testrunner/testrunner.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from jstest.common import paths, reporter, utils
-from jstest.testrunner import utils as testrunnerUtils
+from jstest.testrunner import utils as testrunner_utils
 from jstest.testrunner import devices
 from jstest.testrunner.skiplist import Skiplist
 
@@ -27,7 +27,7 @@ def read_testsets(env):
     # Since JerryScript doesn't have testset descriptor file,
     # simply read the file contents from the test folder.
     if application['name'] == 'jerryscript':
-        testsets = testrunnerUtils.read_test_files(env)
+        testsets = testrunner_utils.read_test_files(env)
     else:
         testsets = utils.read_json_file(application['paths']['testfiles'])
 
@@ -75,7 +75,7 @@ class TestRunner(object):
                 result_dir = utils.join(paths.RESULT_PATH, '%s/%s/' % (app_name, device))
                 result_path = utils.join(result_dir, result_name)
 
-            self.coverage_info = testrunnerUtils.parse_coverage_info(self.env, result_path)
+            self.coverage_info = testrunner_utils.parse_coverage_info(self.env, result_path)
 
             reporter.report_coverage(self.coverage_info)
 
@@ -164,4 +164,4 @@ class TestRunner(object):
         utils.write_json_file(filename + '.json', test_info)
 
         # Publish the results if necessary.
-        testrunnerUtils.upload_data_to_firebase(self.env, test_info)
+        testrunner_utils.upload_data_to_firebase(self.env, test_info)


### PR DESCRIPTION
Some functions were left in API/common/utils.py, moved them to their dedicated spot under API/builder/utils.py and API/testrunner/utils.py

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu