### PR TITLE
Rework __init__.py to use symlink instead of copy at configuration

### DIFF
--- a/jstest/common/utils.py
+++ b/jstest/common/utils.py
@@ -315,3 +315,26 @@ def current_date(date_format):
     Format the current datetime by the given pattern.
     '''
     return time.strftime(date_format)
+
+
+def symlink(src, dst):
+    '''
+    Create a symlink at dst pointing to src
+    '''
+    if not exists(src):
+        return
+
+    # Normalizing path for symlink.
+    src = os.path.normpath(src)
+    dst = os.path.normpath(dst)
+
+    # Existing dst needs to be deleted, since symlink requires non-existing dst.
+    if exists(dst):
+        if os.path.islink(dst):
+            os.unlink(dst)
+        elif os.path.isfile(dst):
+            remove_file(dst)
+        else:
+            rmtree(dst)
+
+    os.symlink(src, dst)

--- a/jstest/resources/__init__.py
+++ b/jstest/resources/__init__.py
@@ -48,7 +48,7 @@ def config_modules(env):
             if not eval(condition):
                 continue
 
-            utils.copy(config['src'], config['dst'])
+            utils.symlink(config['src'], config['dst'])
 
 
 def patch_modules(env, revert=False):

--- a/jstest/resources/patches/nuttx-iotjs-stack.diff
+++ b/jstest/resources/patches/nuttx-iotjs-stack.diff
@@ -1,16 +1,16 @@
-diff --git a/system/iotjs/iotjs_main.c b/system/iotjs/iotjs_main.c
-index 966945e..4f0c411 100644
---- a/system/iotjs/iotjs_main.c
-+++ b/system/iotjs/iotjs_main.c
-@@ -63,14 +63,59 @@
+diff --git a/config/nuttx/stm32f4dis/app/iotjs_main.c b/config/nuttx/stm32f4dis/app/iotjs_main.c
+index 966945e..87399ca 100644
+--- a/config/nuttx/stm32f4dis/app/iotjs_main.c
++++ b/config/nuttx/stm32f4dis/app/iotjs_main.c
+@@ -62,6 +62,7 @@
+ 
  extern int iotjs_entry(int argc, char *argv[]);
  extern int tuv_cleanup(void);
- 
 +#define PATTERN (0xfe)
-+
+ 
  #ifdef CONFIG_BUILD_KERNEL
  extern int main(int argc, FAR char *argv[])
- #else
+@@ -69,8 +70,51 @@ extern int main(int argc, FAR char *argv[])
  extern int iotjs_main(int argc, char *argv[])
  #endif
  {
@@ -48,7 +48,6 @@ index 966945e..4f0c411 100644
 +  asm("mov %0, sp" : "=r" (stack_ptr));
 +  memset(end, PATTERN, stack_ptr - (long int)end);
 +
-+  /* Run IoT.js */
    ret = iotjs_entry(argc, argv);
    tuv_cleanup();
 +
@@ -60,5 +59,6 @@ index 966945e..4f0c411 100644
 +  }
 +
 +  printf ("Stack usage: %d\n", (int) (base - (long int)stack_p));
++
    return ret;
  }

--- a/jstest/resources/patches/nuttx-jerryscript-stack.diff
+++ b/jstest/resources/patches/nuttx-jerryscript-stack.diff
@@ -1,26 +1,23 @@
-diff --git a/interpreters/jerryscript/jerry_main.c b/interpreters/jerryscript/jerry_main.c
-index c644f5e..675b49e 100644
---- a/interpreters/jerryscript/jerry_main.c
-+++ b/interpreters/jerryscript/jerry_main.c
-@@ -39,6 +39,11 @@
+diff --git a/targets/nuttx-stm32f4/jerry_main.c b/targets/nuttx-stm32f4/jerry_main.c
+index 740d4dc..711e3a7 100644
+--- a/targets/nuttx-stm32f4/jerry_main.c
++++ b/targets/nuttx-stm32f4/jerry_main.c
+@@ -38,6 +38,11 @@
+  */
  #define SYNTAX_ERROR_CONTEXT_SIZE 2
- 
- /**
+
++/*
 + * Pattern for stack measurement.
 + */
 +#define PATTERN (0xfe)
 +
-+/**
+ /**
   * Print usage and available options
   */
- static void
-@@ -291,15 +296,9 @@ register_js_function (const char *name_p, /**< name of the function */
- static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
- 
- /**
-- * Main program.
-- *
-- * @return 0 if success, error code otherwise
+@@ -296,12 +301,9 @@ static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
+  * Main program.
+  *
+  * @return 0 if success, error code otherwise
 + * JerryScript entry
   */
 -#ifdef CONFIG_BUILD_KERNEL
@@ -32,68 +29,68 @@ index c644f5e..675b49e 100644
  {
    if (argc > JERRY_MAX_COMMAND_LINE_ARGS)
    {
-@@ -461,6 +460,64 @@ int jerry_main (int argc, char *argv[])
-   jerry_cleanup ();
- 
-   return ret_code;
-+}
-+
-+/**
-+ * Main program.
-+ *
-+ * @return 0 if success, error code otherwise
-+ */
+@@ -466,6 +468,64 @@ int jerry_main (int argc, char *argv[])
+ } /* main */
+
+ /**
+++ * Main program.
+++ *
+++ * @return 0 if success, error code otherwise
+++ */
 +#ifdef CONFIG_BUILD_KERNEL
 +int main (int argc, FAR char *argv[])
 +#else
 +int jerry_main (int argc, char *argv[])
 +#endif
 +{
-+  FILE *fp;
-+  char fname[32];
-+  char stack_info[64];
-+  long int size;
-+  long int base;
-+  long int stack_ptr;
-+  size_t file_size;
++FILE *fp;
++char fname[32];
++char stack_info[64];
++long int size;
++long int base;
++long int stack_ptr;
++size_t file_size;
 +
-+  /*
-+   * Content of /proc/<pid>/stack:
-+   * StackBase:  0x2001a368
-+   * StackSize:  16364
-+   */
++/*
++ * Content of /proc/<pid>/stack:
++ * StackBase:  0x2001a368
++ * StackSize:  16364
++ */
 +
-+  sprintf(fname, "/proc/%d/stack", getpid());
-+  fp = fopen(fname, "r");
-+  if (!fp) {
-+    return 1;
-+  }
++sprintf(fname, "/proc/%d/stack", getpid());
++fp = fopen(fname, "r");
++if (!fp) {
++  return 1;
++}
 +
-+  /* Extract stack info */
-+  file_size = fread(stack_info, 1, 63, fp);
-+  stack_info[file_size] = '\0';
-+  fclose(fp);
++/* Extract stack info */
++file_size = fread(stack_info, 1, 63, fp);
++stack_info[file_size] = '\0';
++fclose(fp);
 +
-+  sscanf(stack_info, "StackBase:  0x%x\nStackSize:  %d", &base, &size);
-+  uint8_t *end = (uint8_t *)(base - size + 4);
++sscanf(stack_info, "StackBase:  0x%x\nStackSize:  %d", &base, &size);
++uint8_t *end = (uint8_t *)(base - size + 4);
 +
-+  /* Stack coloration */
-+  __asm__("mov %0, sp" : "=r" (stack_ptr));
-+  memset(end, PATTERN, stack_ptr - (long int)end);
++/* Stack coloration */
++__asm__("mov %0, sp" : "=r" (stack_ptr));
++memset(end, PATTERN, stack_ptr - (long int)end);
 +
-+  /* Run Jerryscript */
-+  int ret_code = jerry_entry(argc, argv);
++/* Run Jerryscript */
++int ret_code = jerry_entry(argc, argv);
 +
 +/* Check max stack usage */
-+  uint8_t *stack_p = end;
++uint8_t *stack_p = end;
 +
-+  while (*stack_p == PATTERN) {
-+    stack_p++;
-+  }
++while (*stack_p == PATTERN) {
++  stack_p++;
++}
 +
-+  printf ("Stack usage: %d\n", (int) (base - (long int)stack_p));
++printf ("Stack usage: %d\n", (int) (base - (long int)stack_p));
 +
-+  return ret_code;
- } /* main */
- 
- /**
++return ret_code;
++ } /* main */
++
++/**
+  * Aborts the program.
+  */
+ void jerry_port_fatal (jerry_fatal_code_t code)

--- a/jstest/resources/patches/tizenrt-jerryscript-stack.diff
+++ b/jstest/resources/patches/tizenrt-jerryscript-stack.diff
@@ -1,20 +1,19 @@
-diff --git a/apps/system/jerryscript/jerry_main.c b/apps/system/jerryscript/jerry_main.c
-index dc590d8..4d39537 100644
---- a/apps/system/jerryscript/jerry_main.c
-+++ b/apps/system/jerryscript/jerry_main.c
-@@ -42,6 +42,11 @@
+diff --git a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+index dc590d8..f8161f4 100644
+--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
++++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+@@ -40,6 +40,10 @@
+  * Context size of the SYNTAX_ERROR
+  */
  #define SYNTAX_ERROR_CONTEXT_SIZE 2
- 
- /**
++/**
 + * Pattern for stack measurement.
 + */
 +#define PATTERN (0xfe)
-+
-+/**
+
+ /**
   * Print usage and available options
-  */
- static void
-@@ -438,11 +443,49 @@ jerry_cmd_main (int argc, char *argv[])
+@@ -438,11 +442,48 @@ jerry_cmd_main (int argc, char *argv[])
  static int
  jerry(int argc, char *argv[])
  {
@@ -49,9 +48,8 @@ index dc590d8..4d39537 100644
 +  /* Stack coloration */
 +  __asm__("mov %0, sp" : "=r" (stack_ptr));
 +  memset(end, PATTERN, stack_ptr - (unsigned long)end);
-+
    int ret_code = jerry_cmd_main(argc, argv);
- 
+
 -#ifdef CONFIG_DEBUG_VERBOSE
 -  jerry_port_log(JERRY_LOG_LEVEL_DEBUG, "JerryScript result: %d\n", ret_code);
 -#endif
@@ -64,6 +62,6 @@ index dc590d8..4d39537 100644
 +
 +  printf ("Stack usage: %d\n", (int) (base - (unsigned long)stack_p));
 +  printf( "JerryScript result: %d\n", ret_code);
- 
+
    return ret_code;
  } /* jerry */

--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -54,10 +54,6 @@
       "patches": [
         { "file": "%{patches}/tizenrt-openocd.diff", "revert": false},
         {
-          "condition": "'%{app}' == 'jerryscript' and %{memstat}",
-          "file": "%{patches}/tizenrt-jerryscript-stack.diff"
-        },
-        {
           "condition": "'%{app}' == 'iotjs' and %{coverage}",
           "file": "%{patches}/tizenrt-coverage.diff"
         }
@@ -108,14 +104,6 @@
         }
       ],
       "patches": [
-        {
-          "condition": "'%{app}' == 'iotjs' and %{memstat}",
-          "file": "%{patches}/nuttx-iotjs-stack.diff"
-        },
-        {
-          "condition": "'%{app}' == 'jerryscript' and %{memstat}",
-          "file": "%{patches}/nuttx-jerryscript-stack.diff"
-        }
       ]
     },
     "jerryscript": {
@@ -143,6 +131,14 @@
         {
           "condition": "'%{device}' == 'rpi2' and %{memstat}",
           "file": "%{patches}/linux-jerryscript-stack.diff"
+        },
+        {
+          "condition": "'%{device}' == 'stm32f4' and %{memstat}",
+          "file": "%{patches}/nuttx-jerryscript-stack.diff"
+        },
+        {
+          "condition": "'%{device}' == 'artik053' and %{memstat}",
+          "file": "%{patches}/tizenrt-jerryscript-stack.diff"
         }
       ]
     },
@@ -171,6 +167,10 @@
         "js-sources" : "%{iotjs}/src/js/"
       },
       "patches": [
+        {
+          "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
+          "file": "%{patches}/nuttx-iotjs-stack.diff"
+        },
         {
           "condition": "'%{device}' == 'artik053' and %{memstat}",
           "file": "%{patches}/tizenrt-iotjs-stack.diff"


### PR DESCRIPTION
The system used to copy the IoT.js and JerryScript files, when configuring NuttX stm32f4discovery, and TizenRT Artik053 with JerryScript. This way we are separating these libaries from the devices. We don't need to copy these files into the device's directories, we just set up symlinks and patch the original JerryScript and IoT.js it would copy otherwise.

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu