### PR TITLE
Update the local skiplist of the IoT.js project.

### DIFF
--- a/jstest/testrunner/iotjs-skiplist.json
+++ b/jstest/testrunner/iotjs-skiplist.json
@@ -5,19 +5,13 @@
     },
     "stm32f4dis": {
         "testsets": [],
-        "testfiles": [
-            { "name": "test_fs_callbacks_called.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_rename.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_rename_sync.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_writefile.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_writefile_sync.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_writefile_unlink.js", "reason":  "Filesystem tests require writable memory space." },
-            { "name": "test_fs_writefile_unlink_sync.js", "reason":  "Filesystem tests require writable memory space." }
-        ]
+        "testfiles": []
     },
     "artik053": {
         "testsets": [],
-        "testfiles": []
+        "testfiles": [
+            { "name": "test_tls.js", "reason": "Error: SSL setup failed (no enough memory for the test)" }
+        ]
     },
     "artik530": {
         "testsets": [],


### PR DESCRIPTION
The filesystem tests are globally disabled in the `testsets.json`, so it doesn't need to skip them locally.