### PR TITLE
Fix naming in resources.json

### DIFF
--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -133,7 +133,7 @@
           "file": "%{patches}/linux-jerryscript-stack.diff"
         },
         {
-          "condition": "'%{device}' == 'stm32f4' and %{memstat}",
+          "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
           "file": "%{patches}/nuttx-jerryscript-stack.diff"
         },
         {


### PR DESCRIPTION
Thus, the stack usage is added to the memory consumption on STM32F4-discovery.