### PR TITLE
Add error handling into jstest/__main__.py

### DIFF
--- a/jstest/__init__.py
+++ b/jstest/__init__.py
@@ -15,7 +15,7 @@
 import re
 
 from jstest import builder
-from jstest.common import utils, paths
+from jstest.common import console, paths, utils
 from jstest.emulate import pseudo_terminal
 from jstest.testrunner import testrunner
 

--- a/jstest/__main__.py
+++ b/jstest/__main__.py
@@ -166,22 +166,27 @@ def main():
     if os.environ.get('VERBOSE', '') and env['info']['quiet']:
         print('\n\033[1;33mWarning: --quiet option disables VERBOSE output!\033[0m\n')
 
-    # Initialize the testing environment by building all the
-    # required modules to be ready to run tests.
-    builder = jstest.builder.create(env)
-    builder.create_profile_builds()
-    builder.create_test_build()
+    try:
+        # Initialize the testing environment by building all the
+        # required modules to be ready to run tests.
+        builder = jstest.builder.create(env)
+        builder.create_profile_builds()
+        builder.create_test_build()
 
-    # Run all the tests.
-    # FIXME this will have to remain in an if block until
-    # dummy devices are created for the Travis jobs.
-    if not env['info']['no_test']:
-        testrunner = jstest.testrunner.TestRunner(env)
-        testrunner.run()
-        testrunner.save()
-
-        if env['info']['emulate']:
-            jstest.emulate.pseudo_terminal.close_pseudo_terminal(env)
+        # Run all the tests.
+        # FIXME this will have to remain in an if block until
+        # dummy devices are created for the Travis jobs.
+        if not env['info']['no_test']:
+            testrunner = jstest.testrunner.TestRunner(env)
+            testrunner.run()
+            testrunner.save()
+            if env['info']['emulate']:
+                jstest.emulate.pseudo_terminal.close_pseudo_terminal(env)
+    except (Exception, KeyboardInterrupt) as e:
+        jstest.console.log('[Failed] %s' % (str(e)), jstest.console.TERMINAL_RED)
+    finally:
+        # Revert patches if an error occured.
+        jstest.resources.patch_modules(env, revert=True)
 
 
 if __name__ == '__main__':

--- a/jstest/common/console.py
+++ b/jstest/common/console.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-import sys
 
 TERMINAL_RED = '\033[1;31m'
 TERMINAL_BLUE = '\033[1;34m'
@@ -38,9 +37,6 @@ def info(msg):
 
 def fail(msg):
     '''
-    Print a message with red color and exit.
+    Raises an error containing msg, which __main.py__ can catch and print out.
     '''
-    print()
-    print('%s%s%s' % (TERMINAL_RED, msg, TERMINAL_EMPTY))
-    print()
-    sys.exit(1)
+    raise SystemError(msg)


### PR DESCRIPTION
Some configurations need a special patch, which modifies the project files. If an error occoures during execution these modifications would remain. In the `finally` branch of the error handling, these modifications are reverted, and a proper message shows the error.

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu