### PR TITLE
Copy the tester.py script in every cases to ARTIK530 and Raspberry Pi 2 targets

### DIFF
--- a/jstest/builder/modules/freya.build.config
+++ b/jstest/builder/modules/freya.build.config
@@ -58,10 +58,6 @@
       {
         "src": "%{js-remote-test}/jstest/resources/etc/iotjs-freya.config",
         "dst": "%{build-dir}/iotjs-freya.config"
-      },
-      {
-        "src": "%{js-remote-test}/jstest/resources/etc/tester.py",
-        "dst": "%{build-dir}/tester.py"
       }
     ]
   },
@@ -122,10 +118,6 @@
       {
         "src": "%{js-remote-test}/jstest/resources/etc/iotjs-freya.config",
         "dst": "%{build-dir}/iotjs-freya.config"
-      },
-      {
-        "src": "%{js-remote-test}/jstest/resources/etc/tester.py",
-        "dst": "%{build-dir}/tester.py"
       }
     ]
   }

--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -213,6 +213,10 @@
       {
         "src": "%{home}/GBS-ROOT/local/repos/tizen_unified_m1/armv7l/RPMS/%{appname}-1.0.0-0.armv7l.rpm",
         "dst": "%{build-dir}/%{appname}-1.0.0-0.armv7l.rpm"
+      },
+      {
+        "src": "%{js-remote-test}/jstest/resources/etc/tester.py",
+        "dst": "%{build-dir}/tester.py"
       }
     ]
   },
@@ -277,6 +281,10 @@
       {
         "src": "%{iotjs}/test",
         "dst": "%{build-dir}/tests"
+      },
+      {
+        "src": "%{js-remote-test}/jstest/resources/etc/tester.py",
+        "dst": "%{build-dir}/tester.py"
       }
     ]
   }

--- a/jstest/builder/modules/jerryscript.build.config
+++ b/jstest/builder/modules/jerryscript.build.config
@@ -151,6 +151,10 @@
       {
         "src": "%{jerryscript}/tests/jerry",
         "dst": "%{build-dir}/tests"
+      },
+      {
+        "src": "%{js-remote-test}/jstest/resources/etc/tester.py",
+        "dst": "%{build-dir}/tester.py"
       }
     ]
   }


### PR DESCRIPTION
Currently, It was copied only with enabled Freya build,
which is not used in case of JerryScript or no-memstat builds.