### PR TITLE
Enable the usage of user provided tests and testsuite

### DIFF
--- a/jstest/__init__.py
+++ b/jstest/__init__.py
@@ -86,6 +86,9 @@ def create_testing_environment(user_options, job_options):
     if options.app_path:
         modules[options.app].src = options.app_path
 
+    if options.testsuite:
+        modules[options.app].paths.tests = options.testsuite
+
     # Add an 'app' named module that is just a reference
     # to the user defined target application.
     modules.app = modules[options.app]

--- a/jstest/__main__.py
+++ b/jstest/__main__.py
@@ -87,6 +87,10 @@ def parse_options():
                        default=False, action='store_true',
                        help='emulate the connection')
 
+    parser.add_argument('--testsuite',
+                        metavar='TEST_SUITE_PATH',
+                        help='specify the path to user-owned tests')
+
     group = parser.add_argument_group("Secure Shell communication")
 
     group.add_argument('--username',

--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -3,7 +3,7 @@
     "init": [
       {
         "cmd": "function(genromfs)",
-        "args": ["%{iotjs}/test", "%{nuttx-apps}/nshlib/nsh_romfsimg.h"]
+        "args": ["%{testsuite}", "%{nuttx-apps}/nshlib/nsh_romfsimg.h"]
       },
       {
         "cmd": "function(push_environment)",
@@ -60,7 +60,7 @@
         "dst": "%{build-dir}/libs"
       },
       {
-        "src": "%{iotjs}/test",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       }
     ]
@@ -128,7 +128,7 @@
         "dst": "%{build-dir}/libs"
       },
       {
-        "src": "%{iotjs}/test",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       }
     ]
@@ -203,7 +203,7 @@
         "dst": "%{build-dir}/linker.map"
       },
       {
-        "src": "%{iotjs}/test",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       },
       {
@@ -279,7 +279,7 @@
         "dst": "%{build-dir}/linker.map"
       },
       {
-        "src": "%{iotjs}/test",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       },
       {

--- a/jstest/builder/modules/jerryscript.build.config
+++ b/jstest/builder/modules/jerryscript.build.config
@@ -3,7 +3,7 @@
     "init": [
       {
         "cmd": "function(genromfs)",
-        "args": ["%{jerryscript}/tests/jerry/", "%{nuttx-apps}/nshlib/nsh_romfsimg.h"]
+        "args": ["%{testsuite}/", "%{nuttx-apps}/nshlib/nsh_romfsimg.h"]
       },
       {
         "cmd": "function(push_environment)",
@@ -44,7 +44,7 @@
         "dst": "%{build-dir}/libs"
       },
       {
-        "src": "%{jerryscript}/tests/jerry",
+        "src": "testsuite",
         "dst": "%{build-dir}/tests"
       }
     ]
@@ -93,7 +93,7 @@
         "dst": "%{build-dir}/libs"
       },
       {
-        "src": "%{jerryscript}/tests/jerry",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       }
     ]
@@ -149,7 +149,7 @@
         "dst": "%{build-dir}/linker.map"
       },
       {
-        "src": "%{jerryscript}/tests/jerry",
+        "src": "%{testsuite}",
         "dst": "%{build-dir}/tests"
       },
       {

--- a/jstest/common/symbol_resolver.py
+++ b/jstest/common/symbol_resolver.py
@@ -118,7 +118,8 @@ def resolve_symbol(symbol, env):
         'coverage': bool(env.options.coverage),
         'minimal-profile-build': 'minimal-profile-build' in env.options.id,
         'test-build': 'test-build' in env.options.id,
-        'build-dir': env.paths.builddir
+        'build-dir': env.paths.builddir,
+        'testsuite': env.modules.app.paths.tests
     }
 
     return symbol_table.get(symbol, None)

--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -37,13 +37,7 @@
       },
       "config": [
         {
-          "condition": "'%{appname}' == 'iotjs'",
-          "src": "%{iotjs}/test",
-          "dst": "%{tizenrt}/tools/fs/contents/"
-        },
-        {
-          "condition": "'%{appname}' == 'jerryscript'",
-          "src": "%{jerryscript}/tests/jerry",
+          "src": "%{testsuite}",
           "dst": "%{tizenrt}/tools/fs/contents/"
         },
         {

--- a/jstest/testrunner/devices/device_base.py
+++ b/jstest/testrunner/devices/device_base.py
@@ -15,7 +15,7 @@
 import json
 import time
 
-from jstest.common import console
+from jstest.common import console, utils
 from jstest.testrunner import utils as testrunner_utils
 
 class RemoteDevice(object):
@@ -62,6 +62,9 @@ class RemoteDevice(object):
         '''
         Get buildinfo from iotjs.
         '''
+        if not utils.exist_files(self.env.modules.app.paths.tests, ['testsets.json']):
+            return set(), set(), 'stable'
+
         if self.device in ['rpi2', 'artik530']:
             iotjs = '%s/iotjs' % self.workdir
             buildinfo = '%s/tests/tools/iotjs_build_info.js' % self.workdir

--- a/jstest/testrunner/testrunner.py
+++ b/jstest/testrunner/testrunner.py
@@ -22,16 +22,12 @@ def read_testsets(env):
     '''
     Read all the tests into dictionary.
     '''
-    application = env.modules.app
+    testset = utils.join(env.modules.app.paths.tests, 'testsets.json')
 
-    # Since JerryScript doesn't have testset descriptor file,
-    # simply read the file contents from the test folder.
-    if application['name'] == 'jerryscript':
-        testsets = testrunner_utils.read_test_files(env)
-    else:
-        testsets = utils.read_json_file(application.paths['testfiles'])
+    if utils.exists(testset):
+        return utils.read_json_file(testset)
 
-    return testsets
+    return testrunner_utils.read_test_files(env)
 
 
 class TestRunner(object):


### PR DESCRIPTION
Added a new argument `--testsuite <path>` which points to a directory containing tests or testsets.

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu