### PR TITLE
Add some failing tests to the skiplist.

### DIFF
--- a/jstest/testrunner/jerryscript-skiplist.json
+++ b/jstest/testrunner/jerryscript-skiplist.json
@@ -15,7 +15,10 @@
             { "name": "parser-oom.js", "reason": "Requires exactly 512KB memory." },
             { "name": "N.compact-profile-error.js", "reason": "Compact profile is not enabled." },
             { "name": "regression-test-issue-1555.js", "reason": "There's not enough memory to run." },
-            { "name": "regression-test-issue-1997.js", "reason": "There's not enough memory to run." }
+            { "name": "regression-test-issue-1997.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2451.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2452.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2453.js", "reason": "There's not enough memory to run." }
         ]
     },
     "artik053": {
@@ -26,7 +29,10 @@
             { "name": "parser-oom.js", "reason": "Requires exactly 512KB memory." },
             { "name": "N.compact-profile-error.js", "reason": "Compact profile is not enabled." },
             { "name": "regression-test-issue-1555.js", "reason": "There's not enough memory to run." },
-            { "name": "regression-test-issue-1997.js", "reason": "There's not enough memory to run." }
+            { "name": "regression-test-issue-1997.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2451.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2452.js", "reason": "There's not enough memory to run." },
+            { "name": "regression-test-issue-2453.js", "reason": "There's not enough memory to run." }
         ]
     }
 }


### PR DESCRIPTION
The following tests are failing on STM32F4 and ARTIK053 devices in case of JerryScript:
  * regression-test-issue-2451.js
  * regression-test-issue-2452.js
  * regression-test-issue-2453.js

The reason is **out of memory** on both devices.