### PR TITLE
Calculate mbedtls into the binary size.

### DIFF
--- a/jstest/builder/utils.py
+++ b/jstest/builder/utils.py
@@ -25,7 +25,10 @@ _LIBLIST = [
     'libjerry-ext.a',
     'libjerry-port-default.a',
     'libjerry-port-default-minimal.a',
-    'libtuv.a'
+    'libtuv.a',
+    'libmbedx509.a',
+    'libmbedcrypto.a',
+    'libmbedtls.a'
 ]
 
 
@@ -99,11 +102,11 @@ def read_objects_from_libs(libpath, liblist):
     '''
     objlist = []
 
-    for object_file in os.listdir(libpath):
-        if object_file not in liblist:
+    for lib_file in os.listdir(libpath):
+        if lib_file not in liblist:
             continue
 
-        output, _ = utils.execute(libpath, 'ar', ['t', object_file], quiet=True)
+        output, _ = utils.execute(libpath, 'ar', ['t', lib_file], quiet=True)
         objlist.extend(output.splitlines())
 
     return objlist


### PR DESCRIPTION
Currently, the `mbedtls` library is not calculated into the binary size. There is a list that defines which libraries should be calculated into the binary size:

    * libhttpparser.a
    * libiotjs.a
    * libjerry-core.a
    * libjerry-ext.a
    * libjerry-port-default.a
    * libjerry-port-default-minimal.a
    * libtuv.a

This list was not updated when the `curl` based solution (for `https`) was replaced to `mbedtls`.

I've created a measurement with IoT.js (4696d3) on the arm-linux profile (RPi2). This could show how the binary sizes change.

minimal profile |  no mbedtls  (now)     | with mbedtls
------------------ |-----------------------------|-----------------
.text                 | 148190                       |  148238
.data                |  12                              |   580
.rodata             | 36348                         |  34883
.bss                  | 265401                       |  265401
**total**            | **184550 (180.2 K)**  | **183701 (179.3 K)**

arm-linux profile |  no mbedtls  (now)     | with mbedtls
-------------------- |-----------------------------|-----------------
.text                   | 179926                       |  258156
.data                  |  16                              |   928
.rodata               | 117018                       |  128314
.bss                    | 265477                       |  265661
**total**               | **296960 (290.0 K)**  | **387398 (378.3 K)**