### PR TITLE
Fix error in SSHConnection.open

### DIFF
--- a/jstest/testrunner/devices/connections/sshcom.py
+++ b/jstest/testrunner/devices/connections/sshcom.py
@@ -44,7 +44,7 @@ class SSHConnection(object):
         Open the ssh port.
         '''
         self.ssh.connect(hostname=self.ip, port=self.port, username=self.username,
-                         password=self.password, look_for_keys=bool(self.password))
+                         password=self.password, look_for_keys=not bool(self.password))
 
         if self._no_exec_command:
             self.chan = self.ssh.invoke_shell()


### PR DESCRIPTION
The `look_for_keys` argument given to `self.ssh.connect` was wrong and it was not looking for keys when no password was specified. It should be doing the opposite.

JSRemoteTest-DCO-1.0-Signed-off-by: Peter Marki marpeter@inf.u-szeged.hu