### PR TITLE
Fix testsuite argument

### DIFF
--- a/jstest/__main__.py
+++ b/jstest/__main__.py
@@ -182,6 +182,9 @@ def adjust_options(options):
         if utils.get_environment('VERBOSE'):
             jstest.console.warning('--quiet option disables VERBOSE output!')
 
+    if options.testsuite:
+        options.testsuite = utils.abspath(options.testsuite)
+
     return options
 
 


### PR DESCRIPTION
The previous implementation handled relative paths wrong, causing an error. Now all paths are converted into absolute path, to avoid this behaviour.

JSRemoteTest-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu