### PR TITLE
Calculate the mbedtl size into the binary size in case of TizenRT.

### DIFF
--- a/jstest/builder/modules/tizenrt.build.config
+++ b/jstest/builder/modules/tizenrt.build.config
@@ -30,6 +30,10 @@
       {
         "src": "%{tizenrt}/build/output/bin/tinyara.map",
         "dst": "%{build-dir}/linker.map"
+      },
+      {
+        "src": "%{tizenrt}/external/libmbedtls.a",
+        "dst": "%{build-dir}/libs/libmbedtls.a"
       }
     ]
   }

--- a/jstest/builder/utils.py
+++ b/jstest/builder/utils.py
@@ -89,7 +89,9 @@ def calculate_section_sizes(builddir):
             continue
 
         for entry in section['contents']:
-            if any(obj in entry['path'] for obj in objlist):
+            # The objects (from _LIBLIST) have to be at the end of the paths.
+            # E.g. /home/../libraries/libiotjs.a(iotjs.c.obj)
+            if any(entry['path'].endswith('(%s)' % obj) for obj in objlist):
                 section_sizes[section_name] += entry['size']
 
     return section_sizes

--- a/jstest/resources/__init__.py
+++ b/jstest/resources/__init__.py
@@ -52,11 +52,9 @@ def patch_modules(env, revert=False):
     '''
     Modify the source code of the required modules.
     '''
-    if not env.options.patches:
-        return
-
     for module in env.modules.values():
-        for patch in module.get('patches', []):
+        # Get patches that belong to the current job.
+        for patch in module.get('patches', {}).get(env.options.id, []):
             # Do not patch if the result of the condition is false.
             condition = patch.get('condition', 'True')
 

--- a/jstest/resources/patches/tizenrt-coverage.diff
+++ b/jstest/resources/patches/tizenrt-coverage.diff
@@ -1,20 +1,20 @@
 diff --git a/os/FlatLibs.mk b/os/FlatLibs.mk
-index b68dd05..1fb130e 100644
+index de0ec9c..65211e3 100644
 --- a/os/FlatLibs.mk
 +++ b/os/FlatLibs.mk
-@@ -149,6 +149,7 @@ TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libiotjs$(LIBEXT)
+@@ -153,6 +153,7 @@ TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libiotjs$(LIBEXT)
  TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libjerry-core$(LIBEXT)
  TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libtuv$(LIBEXT)
  TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libjerry-libm$(LIBEXT)
 +TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libjerry-port-default$(LIBEXT)
  endif
  
- # Export all libraries
+ # Add library for external bcm support.
 diff --git a/os/LibTargets.mk b/os/LibTargets.mk
-index 6633428..cdaae4a 100644
+index 95be375..3a41a1f 100644
 --- a/os/LibTargets.mk
 +++ b/os/LibTargets.mk
-@@ -233,6 +233,9 @@ $(LIBRARIES_DIR)$(DELIM)libtuv$(LIBEXT): $(IOTJS_LIB_DIR)$(DELIM)libtuv$(LIBEXT)
+@@ -242,6 +242,9 @@ $(LIBRARIES_DIR)$(DELIM)libtuv$(LIBEXT): $(IOTJS_LIB_DIR)$(DELIM)libtuv$(LIBEXT)
  
  $(LIBRARIES_DIR)$(DELIM)libjerry-libm$(LIBEXT): $(IOTJS_LIB_DIR)$(DELIM)libjerry-libm$(LIBEXT)
  	$(Q) install $(IOTJS_LIB_DIR)$(DELIM)libjerry-libm$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libjerry-libm$(LIBEXT)
@@ -25,10 +25,10 @@ index 6633428..cdaae4a 100644
  
  # Possible non-kernel builds
 diff --git a/os/ProtectedLibs.mk b/os/ProtectedLibs.mk
-index 874b809..8341513 100644
+index 42b5fd8..62bbb58 100644
 --- a/os/ProtectedLibs.mk
 +++ b/os/ProtectedLibs.mk
-@@ -147,6 +147,7 @@ USERLIBS += $(LIBRARIES_DIR)$(DELIM)libiotjs$(LIBEXT)
+@@ -148,6 +148,7 @@ USERLIBS += $(LIBRARIES_DIR)$(DELIM)libiotjs$(LIBEXT)
  USERLIBS += $(LIBRARIES_DIR)$(DELIM)libjerry-core$(LIBEXT)
  USERLIBS += $(LIBRARIES_DIR)$(DELIM)libtuv$(LIBEXT)
  USERLIBS += $(LIBRARIES_DIR)$(DELIM)libjerry-libm$(LIBEXT)

--- a/jstest/resources/patches/tizenrt-mbedtls.diff
+++ b/jstest/resources/patches/tizenrt-mbedtls.diff
@@ -1,0 +1,64 @@
+diff --git a/external/mbedtls/Makefile b/external/mbedtls/Makefile
+index 5e321e3..fb174a7 100644
+--- a/external/mbedtls/Makefile
++++ b/external/mbedtls/Makefile
+@@ -99,12 +99,12 @@ SRCS		= $(ASRCS) $(CSRCS)
+ OBJS		= $(AOBJS) $(COBJS)
+ 
+ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+-  BIN		= ..\libexternal$(LIBEXT)
++  BIN		= ..\libmbedtls$(LIBEXT)
+ else
+ ifeq ($(WINTOOL),y)
+-  BIN		= ..\\libexternal$(LIBEXT)
++  BIN		= ..\\libmbedtls$(LIBEXT)
+ else
+-  BIN		= ../libexternal$(LIBEXT)
++  BIN		= ../libmbedtls$(LIBEXT)
+ endif
+ endif
+ 
+diff --git a/os/FlatLibs.mk b/os/FlatLibs.mk
+index 00c6716..de0ec9c 100644
+--- a/os/FlatLibs.mk
++++ b/os/FlatLibs.mk
+@@ -88,6 +88,10 @@ endif
+ 
+ TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
+ 
++# Add library for mbedtls support.
++
++TINYARALIBS += $(LIBRARIES_DIR)$(DELIM)libmbedtls$(LIBEXT)
++
+ # Add libraries for network support
+ 
+ ifeq ($(CONFIG_NET),y)
+diff --git a/os/LibTargets.mk b/os/LibTargets.mk
+index ccb5d2c..95be375 100644
+--- a/os/LibTargets.mk
++++ b/os/LibTargets.mk
+@@ -178,6 +178,12 @@ $(EXTDIR)$(DELIM)libexternal$(LIBEXT): context
+ $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT): $(EXTDIR)$(DELIM)libexternal$(LIBEXT)
+ 	$(Q) install $(EXTDIR)$(DELIM)libexternal$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
+ 
++$(EXTDIR)$(DELIM)libmbedtls$(LIBEXT): context
++	$(Q) $(MAKE) -C $(EXTDIR) TOPDIR="$(TOPDIR)" EXTDIR="$(EXTDIR)" libmbedtls$(LIBEXT) KERNEL=n
++
++$(LIBRARIES_DIR)$(DELIM)libmbedtls$(LIBEXT): $(EXTDIR)$(DELIM)libmbedtls$(LIBEXT)
++	$(Q) install $(EXTDIR)$(DELIM)libmbedtls$(LIBEXT) $(LIBRARIES_DIR)$(DELIM)libmbedtls$(LIBEXT)
++
+ #Iotivity Libs
+ 
+ ifeq ($(CONFIG_ENABLE_IOTIVITY),y)
+diff --git a/os/ProtectedLibs.mk b/os/ProtectedLibs.mk
+index 874b809..42b5fd8 100644
+--- a/os/ProtectedLibs.mk
++++ b/os/ProtectedLibs.mk
+@@ -92,6 +92,7 @@ endif
+ 
+ 
+ USERLIBS += $(LIBRARIES_DIR)$(DELIM)libexternal$(LIBEXT)
++USERLIBS += $(LIBRARIES_DIR)$(DELIM)libmbedtls$(LIBEXT)
+ 
+ # Add libraries for iotivity support
+ 

--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -55,13 +55,34 @@
           "dst": "%{tizenrt}/build/configs/artik053/%{appname}/defconfig"
         }
       ],
-      "patches": [
-        { "file": "%{patches}/tizenrt-openocd.diff", "revert": false},
-        {
-          "condition": "'%{appname}' == 'iotjs' and %{coverage}",
-          "file": "%{patches}/tizenrt-coverage.diff"
-        }
-      ]
+      "patches": {
+        "profiles/minimal-profile-build": [
+          {
+            "condition": "'%{appname}' == 'iotjs'",
+            "file": "%{patches}/tizenrt-mbedtls.diff"
+          }
+        ],
+        "profiles/target-profile-build": [
+          {
+            "condition": "'%{appname}' == 'iotjs'",
+            "file": "%{patches}/tizenrt-mbedtls.diff"
+          }
+        ],
+        "test-build": [
+          {
+            "condition": "'%{appname}' == 'iotjs'",
+            "file": "%{patches}/tizenrt-mbedtls.diff"
+          },
+          {
+            "condition": "'%{appname}' == 'iotjs' and %{coverage}",
+            "file": "%{patches}/tizenrt-coverage.diff"
+          },
+          {
+            "file": "%{patches}/tizenrt-openocd.diff",
+            "revert": false
+          }
+        ]
+      }
     },
     "nuttx": {
       "url": "https://bitbucket.org/nuttx/nuttx.git",
@@ -73,8 +94,6 @@
         "include": "%{nuttx}/include",
         "linker-map": "%{nuttx}/arch/arm/src/nuttx.map"
       },
-      "patches": [
-      ],
       "config": [
         {
           "condition": "'%{appname}' == 'iotjs'",
@@ -106,8 +125,6 @@
           "src": "%{jerryscript}/targets/nuttx-stm32f4/",
           "dst": "%{nuttx-apps}/interpreters/jerryscript/"
         }
-      ],
-      "patches": [
       ]
     },
     "jerryscript": {
@@ -131,20 +148,22 @@
         "artik053-toolchain": "%{jerryscript}/cmake/toolchain_mcu_artik053.cmake",
         "rpi2-toolchain": "%{jerryscript}/cmake/toolchain_linux_armv7l.cmake"
       },
-      "patches": [
-        {
-          "condition": "'%{device}' == 'rpi2' and %{memstat}",
-          "file": "%{patches}/linux-jerryscript-stack.diff"
-        },
-        {
-          "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
-          "file": "%{patches}/nuttx-jerryscript-stack.diff"
-        },
-        {
-          "condition": "'%{device}' == 'artik053'",
-          "file": "%{patches}/tizenrt-jerryscript-%{use-stack}.diff"
-        }
-      ]
+      "patches": {
+        "test-build": [
+          {
+            "condition": "'%{device}' == 'rpi2' and %{memstat}",
+            "file": "%{patches}/linux-jerryscript-stack.diff"
+          },
+          {
+            "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
+            "file": "%{patches}/nuttx-jerryscript-stack.diff"
+          },
+          {
+            "condition": "'%{device}' == 'artik053'",
+            "file": "%{patches}/tizenrt-jerryscript-%{use-stack}.diff"
+          }
+        ]
+      }
     },
     "iotjs": {
       "url": "https://github.com/Samsung/iotjs.git",
@@ -170,45 +189,47 @@
         "coverage-client": "%{iotjs}/deps/jerry/jerry-debugger/jerry-client-ws.py",
         "js-sources" : "%{iotjs}/src/js/"
       },
-      "patches": [
-        {
-          "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
-          "file": "%{patches}/nuttx-iotjs-stack.diff"
-        },
-        {
-          "condition": "'%{device}' == 'artik053'",
-          "file": "%{patches}/tizenrt-iotjs-%{use-stack}.diff"
-        },
-        {
-          "condition": "'%{device}' in ['stm32f4dis', 'artik053'] and %{memstat}",
-          "file": "%{patches}/iotjs-system-heap.diff"
-        },
-        {
-          "condition": "'%{device}' in ['stm32f4dis', 'artik053'] and %{memstat}",
-          "file": "%{patches}/libtuv-system-heap.diff",
-          "submodule": "%{iotjs}/deps/libtuv/"
-        },
-        {
-          "condition": "'%{device}' in ['stm32f4dis', 'artik053', 'artik530', 'rpi2'] and %{memstat}",
-          "file": "%{patches}/jerryscript-jerry-heap.diff",
-          "submodule": "%{iotjs}/deps/jerry/"
-        },
-        {
-          "condition": "'%{device}' in ['artik053', 'artik530', 'rpi2'] and %{coverage}",
-          "file": "%{patches}/jerryscript-coverage.diff",
-          "submodule": "%{iotjs}/deps/jerry/"
-        },
-        {
-          "condition": "'%{device}' in ['artik053', 'artik530', 'rpi2'] and %{coverage}",
-          "file": "%{patches}/coverage-client.diff",
-          "submodule": "%{iotjs}/deps/jerry/",
-          "revert": false
-        },
-        {
-          "condition": "'%{device}' in ['artik530', 'rpi2'] and %{memstat}",
-          "file": "%{patches}/linux-iotjs-stack.diff"
-        }
-      ]
+      "patches": {
+        "test-build": [
+          {
+            "condition": "'%{device}' == 'stm32f4dis' and %{memstat}",
+            "file": "%{patches}/nuttx-iotjs-stack.diff"
+          },
+          {
+            "condition": "'%{device}' == 'artik053'",
+            "file": "%{patches}/tizenrt-iotjs-%{use-stack}.diff"
+          },
+          {
+            "condition": "'%{device}' in ['stm32f4dis', 'artik053'] and %{memstat}",
+            "file": "%{patches}/iotjs-system-heap.diff"
+          },
+          {
+            "condition": "'%{device}' in ['stm32f4dis', 'artik053'] and %{memstat}",
+            "file": "%{patches}/libtuv-system-heap.diff",
+            "submodule": "%{iotjs}/deps/libtuv/"
+          },
+          {
+            "condition": "'%{device}' in ['stm32f4dis', 'artik053', 'artik530', 'rpi2'] and %{memstat}",
+            "file": "%{patches}/jerryscript-jerry-heap.diff",
+            "submodule": "%{iotjs}/deps/jerry/"
+          },
+          {
+            "condition": "'%{device}' in ['artik053', 'artik530', 'rpi2'] and %{coverage}",
+            "file": "%{patches}/jerryscript-coverage.diff",
+            "submodule": "%{iotjs}/deps/jerry/"
+          },
+          {
+            "condition": "'%{device}' in ['artik053', 'artik530', 'rpi2'] and %{coverage}",
+            "file": "%{patches}/coverage-client.diff",
+            "submodule": "%{iotjs}/deps/jerry/",
+            "revert": false
+          },
+          {
+            "condition": "'%{device}' in ['artik530', 'rpi2'] and %{memstat}",
+            "file": "%{patches}/linux-iotjs-stack.diff"
+          }
+        ]
+      }
     },
     "freya": {
       "url": "https://github.com/szeged/Freya.git",

--- a/jstest/runnable.jobs
+++ b/jstest/runnable.jobs
@@ -1,7 +1,6 @@
  [
   {
     "id": "profiles/minimal-profile-build",
-    "patches": false,
     "coverage": false,
     "no_memstat": true,
     "no_flash": true,
@@ -9,14 +8,12 @@
   },
   {
     "id": "profiles/target-profile-build",
-    "patches": false,
     "coverage": false,
     "no_memstat": true,
     "no_flash": true,
     "no_test": true
   },
   {
-    "id": "test-build",
-    "patches": true
+    "id": "test-build"
   }
 ]


### PR DESCRIPTION
TizenRT has its own mbedtls version that is compiled into a common `libexternal.a` file. This patch modifies the TizenRT build to move the created object files into a separated `libmbedtls.a` static library.
In this case, all the mbedtls object files can be used when the linker map file is processed.

Note: since the new `tizen-mbedtls.diff` patch file should be applied for all the jobs (minimal-profile, target-profile, test-build), I've removed the `patches` marker from the `runnable.jobs`. Before, that helped to indicate which job should be patches.

Now, the `patches` section (in the  `resources.json`) is divided into 3 parts that helps to define patches for the jobs separately.