### PR TITLE
Fix the library path of JerryScript in case of RPi2.

### DIFF
--- a/jstest/builder/modules/jerryscript.build.config
+++ b/jstest/builder/modules/jerryscript.build.config
@@ -137,7 +137,7 @@
     },
     "artifacts": [
       {
-        "src": "%{jerryscript}/build/%{target}/%{build-type}/lib",
+        "src": "%{jerryscript}/build/lib",
         "dst": "%{build-dir}/libs"
       },
       {


### PR DESCRIPTION
There is no binary size calculation in case of RPi2 because the JerryScript library path is not correct. This patch fixes that issue.