### PR TITLE
Use absolute path when --app-path is used.

### DIFF
--- a/jstest/__main__.py
+++ b/jstest/__main__.py
@@ -186,6 +186,9 @@ def adjust_options(options):
     if options.testsuite:
         options.testsuite = utils.abspath(options.testsuite)
 
+    if options.app_path:
+        options.app_path = utils.abspath(options.app_path)
+
     return options
 
 


### PR DESCRIPTION
If relative path is defined for the `--app-path` option, the build fails. This patch fixes that by converting the `--app-path` value to absolute path.