### PR TITLE
Use es2015-subset JerryScript profile to run Promise tests.

### DIFF
--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -47,6 +47,7 @@
         {
           "condition": "%{test-build}",
           "args": [
+            "--jerry-profile=es2015-subset",
             "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
             "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
             "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -106,6 +107,7 @@
           "condition": "%{test-build}",
           "env": {
             "IOTJS_BUILD_OPTION": [
+              "--jerry-profile=es2015-subset",
               "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
               "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
               "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -181,6 +183,7 @@
           "condition": "%{test-build}",
           "env": {
             "IOTJS_BUILD_OPTION": [
+              "--jerry-profile=es2015-subset",
               "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
               "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
               "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -258,6 +261,7 @@
         {
           "condition": "%{test-build}",
           "args": [
+            "--jerry-profile=es2015-subset",
             "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
             "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
             "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"


### PR DESCRIPTION
This patch helps to enable the Promise related tests in IoT.js by using the `es2015-subset` as JerryScript profile.