### PR TITLE
Calculate the mbedtls memory usage into the IoT.js memory usage.

### DIFF
--- a/jstest/resources/etc/iotjs-freya.config
+++ b/jstest/resources/etc/iotjs-freya.config
@@ -7,9 +7,11 @@
 iotjs     %{iotjs-dirname}/src
 jerry     deps/jerry
 libtuv    deps/libtuv
+mbedtls   deps/mbedtls
 
 [Total] 1
   (jerry)
   (iotjs)
   (libtuv)
+  (mbedtls)
 [other] 1 +

--- a/jstest/resources/memstat/jstest_memstat.c
+++ b/jstest/resources/memstat/jstest_memstat.c
@@ -122,4 +122,9 @@ void print_mem_stat() {
   printf("  Malloc peak allocated: %u bytes\n", peak_allocated_bytes);
 }
 
+
+// Define custom allocator functions for mbedtls of TizenRT.
+void *(*mbedtls_calloc)(size_t n, size_t size) = jstest_calloc;
+void (*mbedtls_free)(void *ptr) = jstest_free;
+
 #endif /* JSTEST_MEMSTAT_ENABLED */

--- a/jstest/resources/patches/tizenrt-mbedtls.diff
+++ b/jstest/resources/patches/tizenrt-mbedtls.diff
@@ -1,7 +1,16 @@
 diff --git a/external/include/mbedtls/config.h b/external/include/mbedtls/config.h
-index 7d5cda4..0f1401f 100644
+index 7d5cda4..57e1501 100644
 --- a/external/include/mbedtls/config.h
 +++ b/external/include/mbedtls/config.h
+@@ -132,7 +132,7 @@
+  *
+  * Enable this layer to allow use of alternative memory allocators.
+  */
+-//#define MBEDTLS_PLATFORM_MEMORY
++#define MBEDTLS_PLATFORM_MEMORY
+ 
+ /**
+  * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
 @@ -678,7 +678,7 @@
   * enabled as well):
   *      MBEDTLS_TLS_ECDH_ANON_WITH_AES_128_CBC_SHA256
@@ -11,6 +20,15 @@ index 7d5cda4..0f1401f 100644
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
+@@ -2178,7 +2178,7 @@
+  *
+  * This module enables abstraction of common (libc) functions.
+  */
+-//#define MBEDTLS_PLATFORM_C
++#define MBEDTLS_PLATFORM_C
+ 
+ /**
+  * \def MBEDTLS_RIPEMD160_C
 diff --git a/external/mbedtls/Makefile b/external/mbedtls/Makefile
 index 5e321e3..fb174a7 100644
 --- a/external/mbedtls/Makefile


### PR DESCRIPTION
Currently, the **IoT.js memory consumption** is calculated from **IoT.js** and **libtuv** memory allocations. Since **mbedtls** is also a part of IoT.js, that module should also calculated into the memory consumption. This patch has the required modifications for that.

For ARM-Linux and Tizen, it's enough just modify the Freya configuration file.  
In case of TizenRT, the mbedtls config file is modified to be able to use the custom jstest memory monitoring allocator functions (instead of the default system allocator functions).