### PR TITLE
Enable custom allocators for mbedtls only for test build.

### DIFF
--- a/jstest/resources/patches/tizenrt-mbedtls.diff
+++ b/jstest/resources/patches/tizenrt-mbedtls.diff
@@ -1,17 +1,19 @@
 diff --git a/external/include/mbedtls/config.h b/external/include/mbedtls/config.h
-index 7d5cda4..57e1501 100644
+index 7d5cda4..64e8187 100644
 --- a/external/include/mbedtls/config.h
 +++ b/external/include/mbedtls/config.h
-@@ -132,7 +132,7 @@
+@@ -132,7 +132,9 @@
   *
   * Enable this layer to allow use of alternative memory allocators.
   */
 -//#define MBEDTLS_PLATFORM_MEMORY
++#if defined(JSTEST_MEMSTAT_ENABLED)
 +#define MBEDTLS_PLATFORM_MEMORY
++#endif
  
  /**
   * \def MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
-@@ -678,7 +678,7 @@
+@@ -678,7 +680,7 @@
   * enabled as well):
   *      MBEDTLS_TLS_ECDH_ANON_WITH_AES_128_CBC_SHA256
   */
@@ -20,12 +22,14 @@ index 7d5cda4..57e1501 100644
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-@@ -2178,7 +2178,7 @@
+@@ -2178,7 +2180,9 @@
   *
   * This module enables abstraction of common (libc) functions.
   */
 -//#define MBEDTLS_PLATFORM_C
++#if defined(JSTEST_MEMSTAT_ENABLED)
 +#define MBEDTLS_PLATFORM_C
++#endif
  
  /**
   * \def MBEDTLS_RIPEMD160_C


### PR DESCRIPTION
If `MBEDTLS_PLATFORM_C` and `MBEDTLS_PLATFORM_MEMORY` are defined for mbedtls, the binary
size is bigger by 1 KB. This patch enables these macros only for the test build.