### PR TITLE
Support es5.1 and es2015-subset profile builds.

### DIFF
--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -45,9 +45,16 @@
           "args": ["--profile=profiles/minimal.profile"]
         },
         {
+          "condition": "%{es5.1-profile-build}",
+          "args": ["--jerry-profile=es5.1"]
+        },
+        {
+          "condition": "%{es2015subset-profile-build} or %{test-build}",
+          "args": ["--jerry-profile=es2015-subset"]
+        },
+        {
           "condition": "%{test-build}",
           "args": [
-            "--jerry-profile=es2015-subset",
             "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
             "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
             "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -113,7 +120,6 @@
           "condition": "%{test-build}",
           "env": {
             "IOTJS_BUILD_OPTION": [
-              "--jerry-profile=es2015-subset",
               "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
               "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
               "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -135,6 +141,18 @@
         {
           "condition": "%{minimal-profile-build}",
           "env": { "IOTJS_BUILD_OPTION": ["--profile=profiles/minimal.profile"] }
+        },
+        {
+          "condition": "%{es5.1-profile-build}",
+          "env": {
+            "IOTJS_BUILD_OPTION": ["--jerry-profile=es5.1"]
+          }
+        },
+        {
+          "condition": "%{es2015subset-profile-build} or %{test-build}",
+          "env": {
+            "IOTJS_BUILD_OPTION": ["--jerry-profile=es2015-subset"]
+          }
         }
       ]
     },
@@ -194,10 +212,21 @@
           "env": { "IOTJS_BUILD_OPTION": ["--profile=profiles/minimal.profile"] }
         },
         {
+          "condition": "%{es5.1-profile-build}",
+          "env": {
+            "IOTJS_BUILD_OPTION": ["--jerry-profile=es5.1"]
+          }
+        },
+        {
+          "condition": "%{es2015subset-profile-build} or %{test-build}",
+          "env": {
+            "IOTJS_BUILD_OPTION": ["--jerry-profile=es2015-subset"]
+          }
+        },
+        {
           "condition": "%{test-build}",
           "env": {
             "IOTJS_BUILD_OPTION": [
-              "--jerry-profile=es2015-subset",
               "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
               "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
               "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"
@@ -273,9 +302,16 @@
           "args": ["--profile=profiles/minimal.profile"]
         },
         {
+          "condition": "%{es5.1-profile-build}",
+          "args": ["--jerry-profile=es5.1"]
+        },
+        {
+          "condition": "%{es2015subset-profile-build} or %{test-build}",
+          "args": ["--jerry-profile=es2015-subset"]
+        },
+        {
           "condition": "%{test-build}",
           "args": [
-            "--jerry-profile=es2015-subset",
             "--external-modules=test/external_modules/mymodule1,test/external_modules/mymodule2",
             "--cmake-param=-DENABLE_MODULE_MYMODULE1=ON",
             "--cmake-param=-DENABLE_MODULE_MYMODULE2=ON"

--- a/jstest/builder/modules/jerryscript.build.config
+++ b/jstest/builder/modules/jerryscript.build.config
@@ -22,7 +22,7 @@
         "--jerry-libm=ON",
         "--all-in-one=OFF",
         "--mem-heap=70",
-        "--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile",
+        "--profile=%{jerryscript}/jerry-core/profiles/minimal.profile",
         "--toolchain=%{jerryscript}/cmake/toolchain_mcu_stm32f4.cmake",
         "--compile-flag=-I%{jerryscript}/targets/nuttx-stm32f4",
         "--compile-flag='-isystem %{nuttx}/include'"
@@ -33,8 +33,12 @@
           "args": ["--mem-stats=ON"]
         },
         {
-          "condition": "%{minimal-profile-build}",
-          "args": ["--profile=%{jerryscript}/jerry-core/profiles/minimal.profile"]
+          "condition": "%{es5.1-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es5.1.profile"]
+        },
+        {
+          "condition": "%{es2015subset-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile"]
         }
       ]
     },
@@ -68,7 +72,7 @@
         "--jerry-libm=ON",
         "--all-in-one=OFF",
         "--mem-heap=70",
-        "--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile",
+        "--profile=%{jerryscript}/jerry-core/profiles/minimal.profile",
         "--toolchain=%{jerryscript}/cmake/toolchain_mcu_artik053.cmake",
         "--compile-flag='-isystem %{tizenrt}/os/include'"
       ],
@@ -82,8 +86,12 @@
           "args": ["--mem-stats=ON"]
         },
         {
-          "condition": "%{minimal-profile-build}",
-          "args": ["--profile=%{jerryscript}/jerry-core/profiles/minimal.profile"]
+          "condition": "%{es5.1-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es5.1.profile"]
+        },
+        {
+          "condition": "%{es2015subset-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile"]
         }
       ]
     },
@@ -118,7 +126,7 @@
         "--all-in-one=OFF",
         "--linker-flag=-Wl,-Map=jerry.map",
         "--toolchain=%{jerryscript}/cmake/toolchain_linux_armv7l.cmake",
-        "--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile"
+        "--profile=%{jerryscript}/jerry-core/profiles/minimal.profile"
       ],
       "conditional-options": [
         {
@@ -130,8 +138,12 @@
           "args": ["--debug"]
         },
         {
-          "condition": "%{minimal-profile-build}",
-          "args": ["--profile=%{jerryscript}/jerry-core/profiles/minimal.profile"]
+          "condition": "%{es5.1-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es5.1.profile"]
+        },
+        {
+          "condition": "%{es2015subset-profile-build}",
+          "args": ["--profile=%{jerryscript}/jerry-core/profiles/es2015-subset.profile"]
         }
       ]
     },

--- a/jstest/common/symbol_resolver.py
+++ b/jstest/common/symbol_resolver.py
@@ -116,8 +116,10 @@ def resolve_symbol(symbol, env):
         'flash': not env.options.no_flash,
         'memstat': not env.options.no_memstat,
         'coverage': bool(env.options.coverage),
-        'minimal-profile-build': 'minimal-profile-build' in env.options.id,
         'test-build': 'test-build' in env.options.id,
+        'minimal-profile-build': 'minimal-profile-build' in env.options.id,
+        'es5.1-profile-build': 'target-es5.1-profile-build' in env.options.id,
+        'es2015subset-profile-build': 'target-es2015subset-profile-build' in env.options.id,
         'build-dir': env.paths.builddir,
         'testsuite': env.modules.app.paths.tests
     }

--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -62,7 +62,13 @@
             "file": "%{patches}/tizenrt-mbedtls.diff"
           }
         ],
-        "profiles/target-profile-build": [
+        "profiles/target-es5.1-profile-build": [
+          {
+            "condition": "'%{appname}' == 'iotjs'",
+            "file": "%{patches}/tizenrt-mbedtls.diff"
+          }
+        ],
+        "profiles/target-es2015subset-profile-build": [
           {
             "condition": "'%{appname}' == 'iotjs'",
             "file": "%{patches}/tizenrt-mbedtls.diff"

--- a/jstest/runnable.jobs
+++ b/jstest/runnable.jobs
@@ -7,7 +7,14 @@
     "no_test": true
   },
   {
-    "id": "profiles/target-profile-build",
+    "id": "profiles/target-es5.1-profile-build",
+    "coverage": false,
+    "no_memstat": true,
+    "no_flash": true,
+    "no_test": true
+  },
+  {
+    "id": "profiles/target-es2015subset-profile-build",
     "coverage": false,
     "no_memstat": true,
     "no_flash": true,

--- a/jstest/testresult.py
+++ b/jstest/testresult.py
@@ -45,7 +45,8 @@ class TestResult(object):
 
         labels = {
             'profiles/minimal-profile-build': 'minimal-profile',
-            'profiles/target-profile-build': 'target-profile'
+            'profiles/target-es5.1-profile-build': 'target-es5.1-profile',
+            'profiles/target-es2015subset-profile-build': 'target-es2015subset-profile'
         }
 
         for job_id, build_path in self.results.iteritems():


### PR DESCRIPTION
This patch defines more profile builds for IoT.js and JerryScript as well. The following enumeration shows which binary measurements are available, and which could be the new ones (by this patch):

IoT.js
  * [Current] profiles/minimal.profile (JerryScript es.5.1)
  * [Current] test/profiles/{nuttx, tizenrt, arm-linux, tizen}.profile (JerryScript es5.1)
  * **[This patch] test/profiles/{nuttx, tizenrt, arm-linux, tizen}.profile (JerryScript es2015-subset)**

JerryScript
  * [Current] jerry-core/profiles/minimal.profile
  * [Current] jerry-core/profiles/es2015-subset.profile
  * **[This patch] jerry-core/profiles/es5.1.profile**
