### PR TITLE
Modify the es5.1-profile-build label in the results.

### DIFF
--- a/jstest/testresult.py
+++ b/jstest/testresult.py
@@ -45,7 +45,7 @@ class TestResult(object):
 
         labels = {
             'profiles/minimal-profile-build': 'minimal-profile',
-            'profiles/target-es5.1-profile-build': 'target-es5.1-profile',
+            'profiles/target-es5.1-profile-build': 'target-es5_1-profile',
             'profiles/target-es2015subset-profile-build': 'target-es2015subset-profile'
         }
 


### PR DESCRIPTION
The Firebase database has a restriction where dot '.' is prohibited in keys.