### PR TITLE
Add binary size calculation for dinamically linked iotjs.

### DIFF
--- a/jstest/builder/modules/iotjs.build.config
+++ b/jstest/builder/modules/iotjs.build.config
@@ -274,6 +274,10 @@
         "dst": "%{build-dir}/tests"
       },
       {
+        "src": "%{tizen-iotjs-dir}/build/%{target}/%{build-type}/lib",
+        "dst": "%{build-dir}/tests/lib"
+      },
+      {
         "src": "%{tizen-rpm-package}",
         "dst": "%{build-dir}/iotjs-1.0.0-0.armv7l.rpm"
       },

--- a/jstest/resources/resources.json
+++ b/jstest/resources/resources.json
@@ -9,7 +9,7 @@
     "build": "%{build-path}/%{appname}/%{device}/%{build-type}",
     "tizen-build-root": "%{build}/tizen-build-root",
     "tizen-iotjs-dir": "%{build}/tizen-build-root/local/BUILD-ROOTS/scratch.armv7l.0/home/abuild/rpmbuild/BUILD/iotjs-1.0.0",
-    "tizen-rpm-package": "%{build}/tizen-build-root/local/repos/tizen50m2/armv7l/RPMS/iotjs-1.0.0-0.armv7l.rpm",
+    "tizen-rpm-package": "%{build}/tizen-build-root/local/BUILD-ROOTS/scratch.armv7l.0/home/abuild/rpmbuild/RPMS/armv7l/iotjs-1.0.0-0.armv7l.rpm",
     "result": "%{result-path}/%{appname}/%{device}"
   },
   "modules": {


### PR DESCRIPTION
This patch also contains path modifications for Tizen.